### PR TITLE
Switch to TEST_* vars

### DIFF
--- a/tests/shared/kitchen-sink-focal-ussuri-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-ussuri-stable.yaml.j2
@@ -8,7 +8,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP00 }}
+      vip: {{ TEST_VIP00 }}
     constraints: mem=1024
   aodh-hacluster:
     charm: cs:~openstack-charmers/hacluster
@@ -26,7 +26,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP01 }}
+      vip: {{ TEST_VIP01 }}
     constraints: mem=1024
   ceilometer-agent:
     charm: cs:~openstack-charmers/ceilometer-agent
@@ -56,7 +56,7 @@ applications:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP02 }}
+      vip: {{ TEST_VIP02 }}
     constraints: mem=1024
   cinder-ceph:
     charm: cs:~openstack-charmers/cinder-ceph
@@ -80,7 +80,7 @@ applications:
       nova-domain: ""
       nova-domain-email: ""
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP03 }}
+      vip: {{ TEST_VIP03 }}
     constraints: mem=1024
   designate-bind:
     charm: cs:~openstack-charmers/designate-bind
@@ -104,7 +104,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP04 }}
+      vip: {{ TEST_VIP04 }}
     constraints: mem=1024
   glance-hacluster:
     charm: cs:~openstack-charmers/hacluster
@@ -116,7 +116,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP05 }}
+      vip: {{ TEST_VIP05 }}
   gnocchi-hacluster:
     charm: cs:~openstack-charmers/hacluster
     options:
@@ -127,7 +127,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP06 }}
+      vip: {{ TEST_VIP06 }}
   heat-hacluster:
     charm: cs:~openstack-charmers/hacluster
     options:
@@ -138,7 +138,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP07 }}
+      vip: {{ TEST_VIP07 }}
     constraints: mem=1024
   keystone-hacluster:
     charm: cs:~openstack-charmers/hacluster
@@ -167,7 +167,7 @@ applications:
       neutron-security-groups: true
       openstack-origin: *openstack-origin
       reverse-dns-lookup: true
-      vip: {{ OS_VIP09 }}
+      vip: {{ TEST_VIP09 }}
     constraints: mem=1024
   neutron-gateway:
     charm: cs:~openstack-charmers/neutron-gateway
@@ -189,7 +189,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP14 }}
+      vip: {{ TEST_VIP14 }}
   placement-hacluster:
     charm: cs:~openstack-charmers/hacluster
     options:
@@ -206,7 +206,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP10 }}
+      vip: {{ TEST_VIP10 }}
     constraints: mem=2048
   nova-compute:
     charm: cs:~openstack-charmers/nova-compute
@@ -222,7 +222,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP11 }}
+      vip: {{ TEST_VIP11 }}
     constraints: mem=1024
   rabbitmq-server:
     charm: cs:~openstack-charmers/rabbitmq-server
@@ -242,7 +242,7 @@ applications:
       openstack-origin: *openstack-origin
       replicas: 3
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
-      vip: {{ OS_VIP12 }}
+      vip: {{ TEST_VIP12 }}
       zone-assignment: manual
     constraints: mem=1024
   swift-storage-z1:
@@ -276,10 +276,10 @@ applications:
     charm: cs:~openstack-charmers/vault
     num_units: 3
     options:
-      ssl-ca: {{ OS_TEST_CACERT }}
-      ssl-cert: {{ OS_TEST_CERT }}
-      ssl-key: {{ OS_TEST_KEY }}
-      vip: {{ OS_VIP13 }}
+      ssl-ca: {{ TEST_CACERT }}
+      ssl-cert: {{ TEST_CERT }}
+      ssl-key: {{ TEST_KEY }}
+      vip: {{ TEST_VIP13 }}
     constraints: mem=1024
   vault-hacluster:
     charm: cs:~openstack-charmers/hacluster

--- a/tests/shared/kitchen-sink-focal-ussuri.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-ussuri.yaml.j2
@@ -8,7 +8,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP00 }}
+      vip: {{ TEST_VIP00 }}
     constraints: mem=1024
   aodh-hacluster:
     charm: cs:~openstack-charmers-next/hacluster
@@ -26,7 +26,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP01 }}
+      vip: {{ TEST_VIP01 }}
     constraints: mem=1024
   ceilometer-agent:
     charm: cs:~openstack-charmers-next/ceilometer-agent
@@ -56,7 +56,7 @@ applications:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP02 }}
+      vip: {{ TEST_VIP02 }}
     constraints: mem=1024
   cinder-ceph:
     charm: cs:~openstack-charmers-next/cinder-ceph
@@ -80,7 +80,7 @@ applications:
       nova-domain: ""
       nova-domain-email: ""
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP03 }}
+      vip: {{ TEST_VIP03 }}
     constraints: mem=1024
   designate-bind:
     charm: cs:~openstack-charmers-next/designate-bind
@@ -104,7 +104,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP04 }}
+      vip: {{ TEST_VIP04 }}
     constraints: mem=1024
   glance-hacluster:
     charm: cs:~openstack-charmers-next/hacluster
@@ -116,7 +116,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP05 }}
+      vip: {{ TEST_VIP05 }}
   gnocchi-hacluster:
     charm: cs:~openstack-charmers-next/hacluster
     options:
@@ -127,7 +127,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP06 }}
+      vip: {{ TEST_VIP06 }}
   heat-hacluster:
     charm: cs:~openstack-charmers-next/hacluster
     options:
@@ -138,7 +138,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP07 }}
+      vip: {{ TEST_VIP07 }}
     constraints: mem=1024
   keystone-hacluster:
     charm: cs:~openstack-charmers-next/hacluster
@@ -167,7 +167,7 @@ applications:
       neutron-security-groups: true
       openstack-origin: *openstack-origin
       reverse-dns-lookup: true
-      vip: {{ OS_VIP09 }}
+      vip: {{ TEST_VIP09 }}
     constraints: mem=1024
   neutron-gateway:
     charm: cs:~openstack-charmers-next/neutron-gateway
@@ -189,7 +189,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP14 }}
+      vip: {{ TEST_VIP14 }}
   placement-hacluster:
     charm: cs:~openstack-charmers-next/hacluster
     options:
@@ -206,7 +206,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP10 }}
+      vip: {{ TEST_VIP10 }}
     constraints: mem=2048
   nova-compute:
     charm: cs:~openstack-charmers-next/nova-compute
@@ -222,7 +222,7 @@ applications:
     num_units: 3
     options:
       openstack-origin: *openstack-origin
-      vip: {{ OS_VIP11 }}
+      vip: {{ TEST_VIP11 }}
     constraints: mem=1024
   rabbitmq-server:
     charm: cs:~openstack-charmers-next/rabbitmq-server
@@ -242,7 +242,7 @@ applications:
       openstack-origin: *openstack-origin
       replicas: 3
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
-      vip: {{ OS_VIP12 }}
+      vip: {{ TEST_VIP12 }}
       zone-assignment: manual
     constraints: mem=1024
   swift-storage-z1:
@@ -276,10 +276,10 @@ applications:
     charm: cs:~openstack-charmers-next/vault
     num_units: 3
     options:
-      ssl-ca: {{ OS_TEST_CACERT }}
-      ssl-cert: {{ OS_TEST_CERT }}
-      ssl-key: {{ OS_TEST_KEY }}
-      vip: {{ OS_VIP13 }}
+      ssl-ca: {{ TEST_CACERT }}
+      ssl-cert: {{ TEST_CERT }}
+      ssl-key: {{ TEST_KEY }}
+      vip: {{ TEST_VIP13 }}
     constraints: mem=1024
   vault-hacluster:
     charm: cs:~openstack-charmers-next/hacluster


### PR DESCRIPTION
Switch to using TEST rather than OS as a prefix for env vars as
OS is deprecated. See also *1

*1 https://github.com/openstack-charmers/zaza-openstack-tests/pull/346