### PR TITLE
Add designate tempest plugin

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ git+https://opendev.org/openstack/tempest.git#egg=tempest;python_version>='3.6'
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack
 git+https://opendev.org/openstack/cinder-tempest-plugin.git#egg=cinder-tempest-plugin;python_version>='3.6'
+git+https://opendev.org/openstack/designate-tempest-plugin.git#egg=designate-tempest-plugin;python_version>='3.6'

--- a/tests/distro-regression/tests/bundles/bionic-queens.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-queens.yaml
@@ -47,7 +47,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.

--- a/tests/distro-regression/tests/bundles/bionic-rocky.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-rocky.yaml
@@ -53,7 +53,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.

--- a/tests/distro-regression/tests/bundles/bionic-stein.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-stein.yaml
@@ -53,7 +53,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.

--- a/tests/distro-regression/tests/bundles/bionic-train.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-train.yaml
@@ -53,7 +53,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.

--- a/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
@@ -53,7 +53,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.

--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -59,7 +59,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -59,7 +59,7 @@ applications:
     charm: cs:~openstack-charmers-next/designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.

--- a/tests/distro-regression/tests/bundles/groovy-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/groovy-victoria.yaml
@@ -59,7 +59,7 @@ applications:
     charm: cs:~openstack-charmers-next/designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.

--- a/tests/distro-regression/tests/bundles/trusty-mitaka.yaml
+++ b/tests/distro-regression/tests/bundles/trusty-mitaka.yaml
@@ -37,6 +37,20 @@ applications:
     constraints: mem=1024
   cinder-ceph:
     charm: cs:cinder-ceph
+  designate:
+    charm: cs:designate
+    num_units: 1
+    options:
+      nameservers: ns1.ubuntu.com.
+      neutron-domain: serverstack.ubuntu.com.
+      neutron-domain-email: bob@serverstack.ubuntu.com
+      nova-domain: serverstack.ubuntu.com.
+      nova-domain-email: bob@serverstack.ubuntu.com
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  designate-bind:
+    charm: cs:designate-bind
+    num_units: 1
   glance:
     charm: cs:glance
     num_units: 1
@@ -54,6 +68,10 @@ applications:
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
+    constraints: mem=1024
+  memcached:
+    charm: cs:memcached
+    num_units: 1
     constraints: mem=1024
   mongodb:
     charm: cs:trusty/mongodb-53
@@ -241,9 +259,19 @@ relations:
   - neutron-gateway:neutron-plugin-api
 - - neutron-openvswitch:neutron-plugin
   - nova-compute:neutron-plugin
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
 - - neutron-openvswitch:amqp
   - rabbitmq-server:amqp
 - - ceph-osd:mon
   - ceph-mon:osd
 - - ceilometer:shared-db
   - mongodb:database
+- - designate:identity-service
+  - keystone:identity-service
+- - designate:amqp
+  - rabbitmq-server:amqp
+- - designate:dns-backend
+  - designate-bind:dns-backend
+- - designate:coordinator-memcached
+  - memcached:cache

--- a/tests/distro-regression/tests/bundles/xenial-mitaka.yaml
+++ b/tests/distro-regression/tests/bundles/xenial-mitaka.yaml
@@ -47,7 +47,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.
@@ -265,6 +265,8 @@ relations:
   - neutron-gateway:neutron-plugin-api
 - - neutron-openvswitch:neutron-plugin
   - nova-compute:neutron-plugin
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
 - - neutron-openvswitch:amqp
   - rabbitmq-server:amqp
 - - ceph-osd:mon

--- a/tests/distro-regression/tests/bundles/xenial-newton.yaml
+++ b/tests/distro-regression/tests/bundles/xenial-newton.yaml
@@ -47,7 +47,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.
@@ -265,6 +265,8 @@ relations:
   - neutron-gateway:neutron-plugin-api
 - - neutron-openvswitch:neutron-plugin
   - nova-compute:neutron-plugin
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
 - - neutron-openvswitch:amqp
   - rabbitmq-server:amqp
 - - ceph-osd:mon

--- a/tests/distro-regression/tests/bundles/xenial-ocata.yaml
+++ b/tests/distro-regression/tests/bundles/xenial-ocata.yaml
@@ -47,7 +47,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.

--- a/tests/distro-regression/tests/bundles/xenial-pike.yaml
+++ b/tests/distro-regression/tests/bundles/xenial-pike.yaml
@@ -47,7 +47,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.

--- a/tests/distro-regression/tests/bundles/xenial-queens.yaml
+++ b/tests/distro-regression/tests/bundles/xenial-queens.yaml
@@ -47,7 +47,7 @@ applications:
     charm: cs:designate
     num_units: 1
     options:
-      nameservers: ns1.ubuntu.com
+      nameservers: ns1.ubuntu.com.
       neutron-domain: serverstack.ubuntu.com.
       neutron-domain-email: bob@serverstack.ubuntu.com
       nova-domain: serverstack.ubuntu.com.


### PR DESCRIPTION
This change also includes putting designate into the trusty-mitaka bundle, and configuring
designate correctly in all of the bundles.

From a test run with Bionic Stein:

```
{3} designate_tempest_plugin.tests.api.v2.test_recordset.RecordsetsTest.test_create_recordset [0.284242s] ... ok
{3} designate_tempest_plugin.tests.api.v2.test_zones.ZonesTest.test_delete_zone [6.939379s] ... ok
{2} designate_tempest_plugin.tests.scenario.v2.test_zones.ZonesTest.test_create_and_delete_zone [13.293735s] ... ok
{0} designate_tempest_plugin.tests.api.v2.test_zones_exports.ZonesExportTest.test_show_zone_export [7.070915s] ... ok
{0} designate_tempest_plugin.tests.api.v2.test_zones_imports.ZonesImportTest.test_show_zone_import [7.889558s] ... ok
```