### PR TITLE
Update the mysql-innodb-cluster stable cs link

### DIFF
--- a/tests/shared/kitchen-sink-focal-ussuri-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-ussuri-stable.yaml.j2
@@ -150,7 +150,7 @@ applications:
     charm: cs:~memcached-team/memcached
     num_units: 1
   mysql-innodb-cluster:
-    charm: cs:~gnuoy/mysql-innodb-cluster-3
+    charm: cs:~openstack-charmers/mysql-innodb-cluster
     constraints: mem=3072M
     num_units: 3
     options:


### PR DESCRIPTION
Change it to the cs:~openstack-charmers/mysql-innodb-cluster

This is so that it does pick up the (now) stable release of the charms
when doing the charm upgrade test.