### PR TITLE
Add octavia support

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,5 @@ git+https://opendev.org/openstack/designate-tempest-plugin.git#egg=designate-tem
 cinder-tempest-plugin;python_version<'3.6'
 designate-tempest-plugin;python_version<'3.6'
 setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
+git+https://opendev.org/openstack/octavia-tempest-plugin.git#egg=octavia-tempest-plugin;python_version>='3.6'
+octavia-tempest-plugin;python_version<'3.6'

--- a/tests/distro-regression/tests/bundles/bionic-rocky.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-rocky.yaml
@@ -185,6 +185,33 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+  neutron-openvswitch-octavia:
+    series: bionic
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+    num_units: 0
+    options:
+      debug: True
+      prevent-arp-spoofing: False
+      firewall-driver: openvswitch
+  octavia:
+    charm: cs:octavia
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      spare-pool-size: 2
+      loadbalancer-topology: 'ACTIVE_STANDBY'
+  glance-simplestreams-sync:
+    charm: cs:glance-simplestreams-sync
+    num_units: 1
+    options:
+      source: ppa:simplestreams-dev/trunk
+      use_swift: true
+  octavia-diskimage-retrofit:
+    charm: cs:octavia-diskimage-retrofit
+    options:
+      amp-image-tag: 'octavia-amphora'
+      retrofit-uca-pocket: rocky
+      retrofit-series: bionic
 relations:
 - - keystone:shared-db
   - mysql:shared-db
@@ -314,3 +341,23 @@ relations:
   - rabbitmq-server:amqp
 - - barbican:identity-service
   - keystone:identity-service
+- - mysql:shared-db
+  - octavia:shared-db
+- - keystone:identity-service
+  - octavia:identity-service
+- - rabbitmq-server:amqp
+  - octavia:amqp
+- - neutron-api:neutron-load-balancer
+  - octavia:neutron-api
+- - rabbitmq-server:amqp
+  - neutron-openvswitch-octavia:amqp
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch-octavia:neutron-plugin-api
+- - neutron-openvswitch-octavia:neutron-plugin
+  - octavia:neutron-openvswitch
+- - glance-simplestreams-sync:juju-info
+  - octavia-diskimage-retrofit:juju-info
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - keystone:identity-credentials
+  - octavia-diskimage-retrofit:identity-credentials

--- a/tests/distro-regression/tests/bundles/bionic-stein.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-stein.yaml
@@ -185,6 +185,33 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+  neutron-openvswitch-octavia:
+    series: bionic
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+    num_units: 0
+    options:
+      debug: True
+      prevent-arp-spoofing: False
+      firewall-driver: openvswitch
+  octavia:
+    charm: cs:octavia
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      spare-pool-size: 2
+      loadbalancer-topology: 'ACTIVE_STANDBY'
+  glance-simplestreams-sync:
+    charm: cs:glance-simplestreams-sync
+    num_units: 1
+    options:
+      source: ppa:simplestreams-dev/trunk
+      use_swift: true
+  octavia-diskimage-retrofit:
+    charm: cs:octavia-diskimage-retrofit
+    options:
+      amp-image-tag: 'octavia-amphora'
+      retrofit-uca-pocket: rocky
+      retrofit-series: bionic
 relations:
 - - keystone:shared-db
   - mysql:shared-db
@@ -314,3 +341,23 @@ relations:
   - rabbitmq-server:amqp
 - - barbican:identity-service
   - keystone:identity-service
+- - mysql:shared-db
+  - octavia:shared-db
+- - keystone:identity-service
+  - octavia:identity-service
+- - rabbitmq-server:amqp
+  - octavia:amqp
+- - neutron-api:neutron-load-balancer
+  - octavia:neutron-api
+- - rabbitmq-server:amqp
+  - neutron-openvswitch-octavia:amqp
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch-octavia:neutron-plugin-api
+- - neutron-openvswitch-octavia:neutron-plugin
+  - octavia:neutron-openvswitch
+- - glance-simplestreams-sync:juju-info
+  - octavia-diskimage-retrofit:juju-info
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - keystone:identity-credentials
+  - octavia-diskimage-retrofit:identity-credentials

--- a/tests/distro-regression/tests/bundles/bionic-train.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-train.yaml
@@ -191,6 +191,33 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+  neutron-openvswitch-octavia:
+    series: bionic
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+    num_units: 0
+    options:
+      debug: True
+      prevent-arp-spoofing: False
+      firewall-driver: openvswitch
+  octavia:
+    charm: cs:octavia
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      spare-pool-size: 2
+      loadbalancer-topology: 'ACTIVE_STANDBY'
+  glance-simplestreams-sync:
+    charm: cs:glance-simplestreams-sync
+    num_units: 1
+    options:
+      source: ppa:simplestreams-dev/trunk
+      use_swift: true
+  octavia-diskimage-retrofit:
+    charm: cs:octavia-diskimage-retrofit
+    options:
+      amp-image-tag: 'octavia-amphora'
+      retrofit-uca-pocket: rocky
+      retrofit-series: bionic
 relations:
 - - keystone:shared-db
   - mysql:shared-db
@@ -326,3 +353,23 @@ relations:
   - nova-cloud-controller:placement
 - - placement:shared-db
   - mysql:shared-db
+- - mysql:shared-db
+  - octavia:shared-db
+- - keystone:identity-service
+  - octavia:identity-service
+- - rabbitmq-server:amqp
+  - octavia:amqp
+- - neutron-api:neutron-load-balancer
+  - octavia:neutron-api
+- - rabbitmq-server:amqp
+  - neutron-openvswitch-octavia:amqp
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch-octavia:neutron-plugin-api
+- - neutron-openvswitch-octavia:neutron-plugin
+  - octavia:neutron-openvswitch
+- - glance-simplestreams-sync:juju-info
+  - octavia-diskimage-retrofit:juju-info
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - keystone:identity-credentials
+  - octavia-diskimage-retrofit:identity-credentials

--- a/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
@@ -193,6 +193,33 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+  neutron-openvswitch-octavia:
+    series: bionic
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+    num_units: 0
+    options:
+      debug: True
+      prevent-arp-spoofing: False
+      firewall-driver: openvswitch
+  octavia:
+    charm: cs:octavia
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      spare-pool-size: 2
+      loadbalancer-topology: 'ACTIVE_STANDBY'
+  glance-simplestreams-sync:
+    charm: cs:glance-simplestreams-sync
+    num_units: 1
+    options:
+      source: ppa:simplestreams-dev/trunk
+      use_swift: true
+  octavia-diskimage-retrofit:
+    charm: cs:octavia-diskimage-retrofit
+    options:
+      amp-image-tag: 'octavia-amphora'
+      retrofit-uca-pocket: rocky
+      retrofit-series: bionic
 relations:
 - - keystone:shared-db
   - mysql:shared-db
@@ -328,3 +355,23 @@ relations:
   - nova-cloud-controller:placement
 - - placement:shared-db
   - mysql:shared-db
+- - mysql:shared-db
+  - octavia:shared-db
+- - keystone:identity-service
+  - octavia:identity-service
+- - rabbitmq-server:amqp
+  - octavia:amqp
+- - neutron-api:neutron-load-balancer
+  - octavia:neutron-api
+- - rabbitmq-server:amqp
+  - neutron-openvswitch-octavia:amqp
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch-octavia:neutron-plugin-api
+- - neutron-openvswitch-octavia:neutron-plugin
+  - octavia:neutron-openvswitch
+- - glance-simplestreams-sync:juju-info
+  - octavia-diskimage-retrofit:juju-info
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - keystone:identity-credentials
+  - octavia-diskimage-retrofit:identity-credentials

--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -210,6 +210,35 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+  neutron-openvswitch-octavia:
+    series: bionic
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+    num_units: 0
+    options:
+      debug: True
+      prevent-arp-spoofing: False
+      firewall-driver: openvswitch
+  octavia:
+    charm: cs:octavia
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      spare-pool-size: 2
+      loadbalancer-topology: 'ACTIVE_STANDBY'
+  octavia-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  glance-simplestreams-sync:
+    charm: cs:glance-simplestreams-sync
+    num_units: 1
+    options:
+      source: ppa:simplestreams-dev/trunk
+      use_swift: true
+  octavia-diskimage-retrofit:
+    charm: cs:octavia-diskimage-retrofit
+    options:
+      amp-image-tag: 'octavia-amphora'
+      retrofit-uca-pocket: rocky
+      retrofit-series: bionic
 relations:
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp
@@ -401,3 +430,31 @@ relations:
   - placement-mysql-router:shared-db
 - - vault-mysql-router:db-router
   - mysql-innodb-cluster:db-router
+- - octavia-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - octavia-mysql-router:shared-db
+  - octavia:shared-db
+- - keystone:identity-service
+  - octavia:identity-service
+- - rabbitmq-server:amqp
+  - octavia:amqp
+- - neutron-api:neutron-load-balancer
+  - octavia:neutron-api
+- - rabbitmq-server:amqp
+  - neutron-openvswitch-octavia:amqp
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch-octavia:neutron-plugin-api
+- - neutron-openvswitch-octavia:neutron-plugin
+  - octavia:neutron-openvswitch
+- - glance-simplestreams-sync:juju-info
+  - octavia-diskimage-retrofit:juju-info
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - keystone:identity-credentials
+  - octavia-diskimage-retrofit:identity-credentials
+- - vault:certificates
+  - octavia:certificates
+- - vault:certificates
+  - octavia-diskimage-retrofit:certificates
+- - vault:certificates
+  - glance-simplestreams-sync:certificates

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -210,6 +210,35 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+  neutron-openvswitch-octavia:
+    series: bionic
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+    num_units: 0
+    options:
+      debug: True
+      prevent-arp-spoofing: False
+      firewall-driver: openvswitch
+  octavia:
+    charm: cs:octavia
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      spare-pool-size: 2
+      loadbalancer-topology: 'ACTIVE_STANDBY'
+  octavia-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  glance-simplestreams-sync:
+    charm: cs:glance-simplestreams-sync
+    num_units: 1
+    options:
+      source: ppa:simplestreams-dev/trunk
+      use_swift: true
+  octavia-diskimage-retrofit:
+    charm: cs:octavia-diskimage-retrofit
+    options:
+      amp-image-tag: 'octavia-amphora'
+      retrofit-uca-pocket: rocky
+      retrofit-series: bionic
 relations:
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp
@@ -401,3 +430,31 @@ relations:
   - placement-mysql-router:shared-db
 - - vault-mysql-router:db-router
   - mysql-innodb-cluster:db-router
+- - octavia-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - octavia-mysql-router:shared-db
+  - octavia:shared-db
+- - keystone:identity-service
+  - octavia:identity-service
+- - rabbitmq-server:amqp
+  - octavia:amqp
+- - neutron-api:neutron-load-balancer
+  - octavia:neutron-api
+- - rabbitmq-server:amqp
+  - neutron-openvswitch-octavia:amqp
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch-octavia:neutron-plugin-api
+- - neutron-openvswitch-octavia:neutron-plugin
+  - octavia:neutron-openvswitch
+- - glance-simplestreams-sync:juju-info
+  - octavia-diskimage-retrofit:juju-info
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - keystone:identity-credentials
+  - octavia-diskimage-retrofit:identity-credentials
+- - vault:certificates
+  - octavia:certificates
+- - vault:certificates
+  - octavia-diskimage-retrofit:certificates
+- - vault:certificates
+  - glance-simplestreams-sync:certificates

--- a/tests/distro-regression/tests/bundles/groovy-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/groovy-victoria.yaml
@@ -210,6 +210,35 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+  neutron-openvswitch-octavia:
+    series: bionic
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+    num_units: 0
+    options:
+      debug: True
+      prevent-arp-spoofing: False
+      firewall-driver: openvswitch
+  octavia:
+    charm: cs:octavia
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      spare-pool-size: 2
+      loadbalancer-topology: 'ACTIVE_STANDBY'
+  octavia-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  glance-simplestreams-sync:
+    charm: cs:glance-simplestreams-sync
+    num_units: 1
+    options:
+      source: ppa:simplestreams-dev/trunk
+      use_swift: true
+  octavia-diskimage-retrofit:
+    charm: cs:octavia-diskimage-retrofit
+    options:
+      amp-image-tag: 'octavia-amphora'
+      retrofit-uca-pocket: rocky
+      retrofit-series: bionic
 relations:
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp
@@ -401,3 +430,31 @@ relations:
   - placement-mysql-router:shared-db
 - - vault-mysql-router:db-router
   - mysql-innodb-cluster:db-router
+- - octavia-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - octavia-mysql-router:shared-db
+  - octavia:shared-db
+- - keystone:identity-service
+  - octavia:identity-service
+- - rabbitmq-server:amqp
+  - octavia:amqp
+- - neutron-api:neutron-load-balancer
+  - octavia:neutron-api
+- - rabbitmq-server:amqp
+  - neutron-openvswitch-octavia:amqp
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch-octavia:neutron-plugin-api
+- - neutron-openvswitch-octavia:neutron-plugin
+  - octavia:neutron-openvswitch
+- - glance-simplestreams-sync:juju-info
+  - octavia-diskimage-retrofit:juju-info
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - keystone:identity-credentials
+  - octavia-diskimage-retrofit:identity-credentials
+- - vault:certificates
+  - octavia:certificates
+- - vault:certificates
+  - octavia-diskimage-retrofit:certificates
+- - vault:certificates
+  - glance-simplestreams-sync:certificates

--- a/tests/distro-regression/tests/tests.yaml
+++ b/tests/distro-regression/tests/tests.yaml
@@ -7,9 +7,9 @@ smoke_bundles:
   - keystone_v3_smoke: xenial-queens
   - keystone_v3_smoke: bionic-queens
   - keystone_v3_smoke_rocky: bionic-rocky
-  - keystone_v3_smoke_octavia: bionic-stein
-  - keystone_v3_smoke_octavia: bionic-train
-  - keystone_v3_smoke_octavia: bionic-ussuri
+  - keystone_v3_smoke_stein: bionic-stein
+  - keystone_v3_smoke_stein: bionic-train
+  - keystone_v3_smoke_stein: bionic-ussuri
   - keystone_v3_smoke_focal: focal-ussuri
   - keystone_v3_smoke_focal: focal-victoria
   - keystone_v3_smoke_focal: groovy-victoria
@@ -52,7 +52,7 @@ configure:
     - zaza.openstack.charm_tests.glance.setup.add_cirros_alt_image
     - zaza.openstack.charm_tests.octavia.setup.centralized_fip_network
     - zaza.openstack.charm_tests.tempest.setup.render_tempest_config_keystone_v3
-  - keystone_v3_smoke_octavia:
+  - keystone_v3_smoke_stein:
     - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
     - zaza.openstack.charm_tests.glance_simplestreams_sync.setup.sync_images
     - zaza.openstack.charm_tests.glance.setup.add_lts_image
@@ -92,7 +92,7 @@ tests:
     - zaza.openstack.charm_tests.tempest.tests.TempestTest
   - keystone_v3_smoke_rocky:
     - zaza.openstack.charm_tests.tempest.tests.TempestTest
-  - keystone_v3_smoke_octavia:
+  - keystone_v3_smoke_stein:
     - zaza.openstack.charm_tests.tempest.tests.TempestTest
   - keystone_v3_smoke_focal:
     - zaza.openstack.charm_tests.tempest.tests.TempestTest
@@ -106,7 +106,7 @@ tests_options:
       smoke: True
       blacklist:
         - "tempest.api.identity.v3.test_domains.DefaultDomainTestJSON.test_default_domain_exists"
-    keystone_v3_smoke_octavia:
+    keystone_v3_smoke_stein:
       smoke: True
     keystone_v3_smoke_focal:
       smoke: True

--- a/tests/distro-regression/tests/tests.yaml
+++ b/tests/distro-regression/tests/tests.yaml
@@ -7,9 +7,9 @@ smoke_bundles:
   - keystone_v3_smoke: xenial-queens
   - keystone_v3_smoke: bionic-queens
   - keystone_v3_smoke_rocky: bionic-rocky
-  - keystone_v3_smoke: bionic-stein
-  - keystone_v3_smoke: bionic-train
-  - keystone_v3_smoke: bionic-ussuri
+  - keystone_v3_smoke_octavia: bionic-stein
+  - keystone_v3_smoke_octavia: bionic-train
+  - keystone_v3_smoke_octavia: bionic-ussuri
   - keystone_v3_smoke_focal: focal-ussuri
   - keystone_v3_smoke_focal: focal-victoria
   - keystone_v3_smoke_focal: groovy-victoria
@@ -38,7 +38,11 @@ configure:
     - zaza.openstack.charm_tests.tempest.setup.render_tempest_config_keystone_v3
   - keystone_v3_smoke_rocky:
     - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
+    - zaza.openstack.charm_tests.glance_simplestreams_sync.setup.sync_images
     - zaza.openstack.charm_tests.glance.setup.add_lts_image
+    - zaza.openstack.charm_tests.octavia.setup.ensure_lts_images
+    - zaza.openstack.charm_tests.octavia.diskimage_retrofit.setup.retrofit_amphora_image
+    - zaza.openstack.charm_tests.octavia.setup.configure_octavia
     - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
     - zaza.openstack.charm_tests.nova.setup.create_flavors
     - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
@@ -46,11 +50,32 @@ configure:
     - zaza.openstack.charm_tests.keystone.setup.add_tempest_roles
     - zaza.openstack.charm_tests.glance.setup.add_cirros_image
     - zaza.openstack.charm_tests.glance.setup.add_cirros_alt_image
+    - zaza.openstack.charm_tests.octavia.setup.centralized_fip_network
+    - zaza.openstack.charm_tests.tempest.setup.render_tempest_config_keystone_v3
+  - keystone_v3_smoke_octavia:
+    - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
+    - zaza.openstack.charm_tests.glance_simplestreams_sync.setup.sync_images
+    - zaza.openstack.charm_tests.glance.setup.add_lts_image
+    - zaza.openstack.charm_tests.octavia.setup.ensure_lts_images
+    - zaza.openstack.charm_tests.octavia.diskimage_retrofit.setup.retrofit_amphora_image
+    - zaza.openstack.charm_tests.octavia.setup.configure_octavia
+    - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+    - zaza.openstack.charm_tests.nova.setup.create_flavors
+    - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+    - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+    - zaza.openstack.charm_tests.keystone.setup.add_tempest_roles
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_image
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_alt_image
+    - zaza.openstack.charm_tests.octavia.setup.centralized_fip_network
     - zaza.openstack.charm_tests.tempest.setup.render_tempest_config_keystone_v3
   - keystone_v3_smoke_focal:
     - zaza.openstack.charm_tests.vault.setup.auto_initialize
     - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
+    - zaza.openstack.charm_tests.glance_simplestreams_sync.setup.sync_images
     - zaza.openstack.charm_tests.glance.setup.add_lts_image
+    - zaza.openstack.charm_tests.octavia.setup.ensure_lts_images
+    - zaza.openstack.charm_tests.octavia.diskimage_retrofit.setup.retrofit_amphora_image
+    - zaza.openstack.charm_tests.octavia.setup.configure_octavia
     - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
     - zaza.openstack.charm_tests.nova.setup.create_flavors
     - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
@@ -58,6 +83,7 @@ configure:
     - zaza.openstack.charm_tests.keystone.setup.add_tempest_roles
     - zaza.openstack.charm_tests.glance.setup.add_cirros_image
     - zaza.openstack.charm_tests.glance.setup.add_cirros_alt_image
+    - zaza.openstack.charm_tests.octavia.setup.centralized_fip_network
     - zaza.openstack.charm_tests.tempest.setup.render_tempest_config_keystone_v3
 tests:
   - keystone_v2_smoke:
@@ -65,6 +91,8 @@ tests:
   - keystone_v3_smoke:
     - zaza.openstack.charm_tests.tempest.tests.TempestTest
   - keystone_v3_smoke_rocky:
+    - zaza.openstack.charm_tests.tempest.tests.TempestTest
+  - keystone_v3_smoke_octavia:
     - zaza.openstack.charm_tests.tempest.tests.TempestTest
   - keystone_v3_smoke_focal:
     - zaza.openstack.charm_tests.tempest.tests.TempestTest
@@ -78,6 +106,8 @@ tests_options:
       smoke: True
       blacklist:
         - "tempest.api.identity.v3.test_domains.DefaultDomainTestJSON.test_default_domain_exists"
+    keystone_v3_smoke_octavia:
+      smoke: True
     keystone_v3_smoke_focal:
       smoke: True
   force_deploy:
@@ -86,12 +116,18 @@ target_deploy_status:
   ceilometer:
     workload-status: blocked
     workload-status-message: "Run the ceilometer-upgrade action on the leader to initialize ceilometer and gnocchi"
+  glance-simplestreams-sync:
+    workload-status: unknown
+    workload-status-message: ""
   mongodb:
     workload-status: unknown
     workload-status-message: ""
   neutron-api-plugin-ovn:
     workload-status: waiting
     workload-status-message: "'certificates' awaiting server certificate data, 'ovsdb-cms' incomplete"
+  octavia:
+    workload-status: blocked
+    workload-status-message: Awaiting
   ovn-central:
     workload-status: waiting
     workload-status-message: "'ovsdb-peer' incomplete, 'certificates' awaiting server certificate data"


### PR DESCRIPTION
In addition to adding octavia to the bundles, this change
adds the octavia-tempest-plugin to the virtualenv so that
the Octavia tempest tests can be run alongside.