### PR TITLE
Upgrade scenario testing changes

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+chardet==3.0.4
 git+https://opendev.org/openstack/tempest.git#egg=tempest;python_version>='3.6'
 tempest;python_version<'3.6'
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza

--- a/tests/charm-upgrade/tests/tests.yaml
+++ b/tests/charm-upgrade/tests/tests.yaml
@@ -9,6 +9,7 @@ configure:
   - zaza.openstack.charm_tests.nova.setup.create_flavors
   - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
 tests:
+  - zaza.openstack.charm_tests.openstack_upgrade.tests.WaitForMySQL
   - zaza.openstack.charm_tests.charm_upgrade.tests.FullCloudCharmUpgradeTest
 smoke_bundles:
   - kitchen-sink-focal-ussuri-stable

--- a/tests/openstack-upgrade/tests/bundles/kitchen-sink-focal-ussuri.yaml.j2
+++ b/tests/openstack-upgrade/tests/bundles/kitchen-sink-focal-ussuri.yaml.j2
@@ -1,0 +1,1 @@
+../../../shared/kitchen-sink-focal-ussuri.yaml.j2

--- a/tests/openstack-upgrade/tests/tests.yaml
+++ b/tests/openstack-upgrade/tests/tests.yaml
@@ -1,0 +1,29 @@
+before_deploy:
+  - kitchen-sink-focal-ussuri:
+    - zaza.openstack.configure.pre_deploy_certs.set_cidr_certs
+configure:
+  - kitchen-sink-focal-ussuri:
+    - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
+    - zaza.openstack.charm_tests.vault.setup.auto_initialize
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_image
+    - zaza.openstack.charm_tests.glance.setup.add_lts_image
+    - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+    - zaza.openstack.charm_tests.nova.setup.create_flavors
+    - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+tests:
+  - kitchen-sink-focal-ussuri:
+    - zaza.openstack.charm_tests.openstack_upgrade.tests.WaitForMySQL
+    - zaza.openstack.charm_tests.openstack_upgrade.tests.OpenStackUpgradeTestsFocalUssuri
+smoke_bundles:
+  - kitchen-sink-focal-ussuri: kitchen-sink-focal-ussuri
+target_deploy_status:
+  easyrsa:
+    workload-status-message: Certificate Authority connected.
+  etcd:
+    workload-status-message: Healthy
+  vault:
+    workload-status: blocked
+    workload-status-message: Vault needs to be initialized
+  ceilometer:
+    workload-status: blocked
+    workload-status-message: "Run the ceilometer-upgrade action on the leader to initialize ceilometer and gnocchi"

--- a/tests/series-upgrade/tests/bundles/bionic-to-focal-ussuri-ha.yaml.j2
+++ b/tests/series-upgrade/tests/bundles/bionic-to-focal-ussuri-ha.yaml.j2
@@ -1,9 +1,9 @@
 # This is the bionic-ussuri to focal-ussuri series upgrade bundle with
 # percona-cluster (at bionic).
 #
-# This bundle does not intend to upgrade perconal cluster to mysql8
+# This bundle does not intend to upgrade percona cluster to mysql8
 # (mysql-innodb-cluster and mysql-router) as that will be handled by the
-# perconal-cluster to mysql8 migration test.
+# percona-cluster to mysql8 migration test.
 #
 # TODO:
 #         - Add SSL everywhere
@@ -30,6 +30,8 @@ applications:
       cluster_count: 3
       corosync_transport: unicast
 
+# NOTE(ajkavanagh): barbican is currently disabled as it's not part of the series upgrade tests
+# It is included to make it easier to enable in the future.
 #  barbican:
 #    charm: cs:~openstack-charmers-next/barbican
 #    num_units: 1

--- a/tests/series-upgrade/tests/bundles/bionic-to-focal-ussuri-ha.yaml.j2
+++ b/tests/series-upgrade/tests/bundles/bionic-to-focal-ussuri-ha.yaml.j2
@@ -1,0 +1,653 @@
+# This is the bionic-ussuri to focal-ussuri series upgrade bundle with
+# percona-cluster (at bionic).
+#
+# This bundle does not intend to upgrade perconal cluster to mysql8
+# (mysql-innodb-cluster and mysql-router) as that will be handled by the
+# perconal-cluster to mysql8 migration test.
+#
+# TODO:
+#         - Add SSL everywhere
+#         - Add HA everywhere
+
+variables:
+  openstack-origin: &openstack-origin cloud:bionic-ussuri
+
+series: bionic
+
+applications:
+
+  aodh:
+    charm: cs:~openstack-charmers-next/aodh
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP00 }}
+    constraints: mem=1024
+
+  aodh-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+#  barbican:
+#    charm: cs:~openstack-charmers-next/barbican
+#    num_units: 1
+#    options:
+#      openstack-origin: *openstack-origin
+#    constraints: mem=1024
+
+  ceilometer:
+    charm: cs:~openstack-charmers-next/ceilometer
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP01 }}
+    constraints: mem=1024
+
+  ceilometer-agent:
+    charm: cs:~openstack-charmers-next/ceilometer-agent
+
+  ceilometer-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  ceph-mon:
+    charm: cs:~openstack-charmers-next/ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *openstack-origin
+
+  ceph-osd:
+    charm: cs:~openstack-charmers-next/ceph-osd
+    num_units: 3
+    options:
+      source: *openstack-origin
+    constraints: mem=1024
+    storage:
+      osd-devices:  cinder,40G
+
+  cinder:
+    charm: cs:~openstack-charmers-next/cinder
+    num_units: 3
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP02 }}
+    constraints: mem=1024
+
+  cinder-ceph:
+    charm: cs:~openstack-charmers-next/cinder-ceph
+
+  cinder-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  dashboard-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  designate:
+    charm: cs:~openstack-charmers-next/designate
+    num_units: 3
+    options:
+      nameservers: ns1.mojo.serverstack.com.
+      neutron-domain: ""
+      neutron-domain-email: ""
+      nova-domain: ""
+      nova-domain-email: ""
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP03 }}
+    constraints: mem=1024
+
+  designate-bind:
+    charm: cs:~openstack-charmers-next/designate-bind
+    num_units: 3
+
+  designate-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+
+  etcd:
+    series: bionic
+    #charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
+    num_units: 3
+    options:
+      channel: 3.1/stable
+
+  glance:
+    charm: cs:~openstack-charmers-next/glance
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP04 }}
+    constraints: mem=1024
+
+  glance-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  gnocchi:
+    charm: cs:~openstack-charmers-next/gnocchi
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP05 }}
+
+  gnocchi-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  heat:
+    charm: cs:~openstack-charmers-next/heat
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP06 }}
+
+  heat-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  keystone:
+    charm: cs:~openstack-charmers-next/keystone
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP07 }}
+    constraints: mem=1024
+
+  keystone-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  memcached:
+    charm: cs:memcached
+    num_units: 1
+
+  percona-cluster:
+    charm: cs:~openstack-charmers-next/percona-cluster
+    constraints: mem=3072M
+    num_units: 1
+    options:
+      #vip: {{ TEST_VIP08 }}
+      source: *openstack-origin
+
+#  percona-hacluster:
+#    charm: cs:~openstack-charmers-next/hacluster
+#    num_units: 0
+#    options:
+#      cluster_count: 3
+
+  neutron-api:
+    charm: cs:~openstack-charmers-next/neutron-api
+    num_units: 3
+    options:
+      manage-neutron-plugin-legacy-mode: True
+      dns-domain: mojo.serverstack.
+      enable-ml2-dns: true
+      flat-network-providers: physnet1
+      ipv4-ptr-zone-prefix-size: 24
+      neutron-security-groups: true
+      openstack-origin: *openstack-origin
+      reverse-dns-lookup: true
+      vip: {{ TEST_VIP09 }}
+    constraints: mem=1024
+
+  neutron-gateway:
+    charm: cs:~openstack-charmers-next/neutron-gateway
+    num_units: 1
+    options:
+      bridge-mappings: physnet1:br-ex
+      instance-mtu: 1300
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+
+  neutron-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  neutron-openvswitch:
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+
+  placement:
+    charm: cs:~openstack-charmers-next/placement
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP14 }}
+
+  placement-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  nova-cc-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  nova-cloud-controller:
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    num_units: 3
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP10 }}
+    constraints: mem=2048
+
+  nova-compute:
+    charm: cs:~openstack-charmers-next/nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+
+  openstack-dashboard:
+    charm: cs:~openstack-charmers-next/openstack-dashboard
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP11 }}
+    constraints: mem=1024
+
+  rabbitmq-server:
+    charm: cs:~openstack-charmers-next/rabbitmq-server
+    num_units: 1
+    options:
+      source: *openstack-origin
+    constraints: mem=4096
+
+  swift-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  swift-proxy:
+    charm: cs:~openstack-charmers-next/swift-proxy
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      vip: {{ TEST_VIP12 }}
+      zone-assignment: manual
+    constraints: mem=1024
+
+  swift-storage-z1:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+
+  swift-storage-z2:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+
+  swift-storage-z3:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+
+  vault:
+    charm: cs:~openstack-charmers-next/vault
+    num_units: 3
+    options:
+      ssl-ca: {{ TEST_CACERT }}
+      ssl-cert: {{ TEST_CERT }}
+      ssl-key: {{ TEST_KEY }}
+      vip: {{ TEST_VIP13 }}
+    constraints: mem=1024
+
+  vault-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+relations:
+- - placement:certificates
+  - vault:certificates
+
+- - placement:ha
+  - placement-hacluster:ha
+
+- - placement:identity-service
+  - keystone:identity-service
+
+- - placement:amqp
+  - rabbitmq-server:amqp
+
+- - nova-cloud-controller:placement
+  - placement:placement
+
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+
+- - nova-cloud-controller:image-service
+  - glance:image-service
+
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+
+- - nova-cloud-controller:memcache
+  - memcached:cache
+
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+
+- - nova-compute:image-service
+  - glance:image-service
+
+- - nova-compute:ceph
+  - ceph-mon:client
+
+- - glance:identity-service
+  - keystone:identity-service
+
+- - glance:ceph
+  - ceph-mon:client
+
+- - glance:image-service
+  - cinder:image-service
+
+- - glance:amqp
+  - rabbitmq-server:amqp
+
+- - cinder:amqp
+  - rabbitmq-server:amqp
+
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+
+- - cinder:identity-service
+  - keystone:identity-service
+
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+
+- - cinder-ceph:ceph
+  - ceph-mon:client
+
+- - neutron-gateway:quantum-network-service
+  - nova-cloud-controller:quantum-network-service
+
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+
+- - swift-proxy:identity-service
+  - keystone:identity-service
+
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+
+- - heat:identity-service
+  - keystone:identity-service
+
+- - heat:amqp
+  - rabbitmq-server:amqp
+
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch:neutron-plugin-api
+
+- - neutron-api:identity-service
+  - keystone:identity-service
+
+- - neutron-api:neutron-plugin-api
+  - neutron-gateway:neutron-plugin-api
+
+- - neutron-openvswitch:neutron-plugin
+  - nova-compute:neutron-plugin
+
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+
+- - ceph-osd:mon
+  - ceph-mon:osd
+
+- - keystone:certificates
+  - vault:certificates
+
+- - neutron-api:certificates
+  - vault:certificates
+
+- - nova-cloud-controller:certificates
+  - vault:certificates
+
+- - swift-proxy:certificates
+  - vault:certificates
+
+- - cinder:certificates
+  - vault:certificates
+
+- - glance:certificates
+  - vault:certificates
+
+- - rabbitmq-server:certificates
+  - vault:certificates
+
+- - heat:certificates
+  - vault:certificates
+
+- - keystone:ha
+  - keystone-hacluster:ha
+
+- - nova-cloud-controller:ha
+  - nova-cc-hacluster:ha
+
+- - cinder:ha
+  - cinder-hacluster:ha
+
+- - glance:ha
+  - glance-hacluster:ha
+
+- - openstack-dashboard:ha
+  - dashboard-hacluster:ha
+
+- - swift-proxy:ha
+  - swift-hacluster:ha
+
+- - neutron-api:ha
+  - neutron-hacluster:ha
+
+- - heat:ha
+  - heat-hacluster:ha
+
+- - vault:ha
+  - vault-hacluster:ha
+
+- - etcd:certificates
+  - easyrsa:client
+
+- - etcd:db
+  - vault:etcd
+
+- - aodh:amqp
+  - rabbitmq-server:amqp
+
+- - aodh:identity-service
+  - keystone:identity-service
+
+- - aodh:ha
+  - aodh-hacluster:ha
+
+- - designate:identity-service
+  - keystone:identity-service
+
+- - designate:amqp
+  - rabbitmq-server:amqp
+
+- - designate:dns-backend
+  - designate-bind:dns-backend
+
+- - designate:coordinator-memcached
+  - memcached:cache
+
+- - designate:dnsaas
+  - neutron-api:external-dns
+
+- - designate:ha
+  - designate-hacluster:ha
+
+- - aodh:certificates
+  - vault:certificates
+
+- - designate:certificates
+  - vault:certificates
+
+- - gnocchi:storage-ceph
+  - ceph-mon:client
+
+- - gnocchi:amqp
+  - rabbitmq-server:amqp
+
+- - gnocchi:coordinator-memcached
+  - memcached:cache
+
+- - gnocchi:metric-service
+  - ceilometer:metric-service
+
+- - gnocchi:identity-service
+  - keystone:identity-service
+
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+
+- - gnocchi:certificates
+  - vault:certificates
+
+- - ceilometer:identity-credentials
+  - keystone:identity-credentials
+
+- - ceilometer:identity-notifications
+  - keystone:identity-notifications
+
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
+
+- - ceilometer-agent:nova-ceilometer
+  - nova-compute:nova-ceilometer
+
+- - ceilometer-agent:ceilometer-service
+  - ceilometer:ceilometer-service
+
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
+
+- - ceilometer:ha
+  - ceilometer-hacluster:ha
+
+- - gnocchi:ha
+  - gnocchi-hacluster:ha
+
+- - ceilometer:certificates
+  - vault:certificates
+
+#- - barbican:amqp
+#  - rabbitmq-server:amqp
+
+#- - barbican:identity-service
+#  - keystone:identity-service
+
+#- - percona-cluster
+#  - percona-hacluster
+
+- - vault:shared-db
+  - percona-cluster:shared-db
+
+- - keystone:shared-db
+  - percona-cluster:shared-db
+
+#- - barbican:shared-db
+#  - percona-cluster:shared-db
+
+- - heat:shared-db
+  - percona-cluster:shared-db
+
+- - nova-cloud-controller:shared-db
+  - percona-cluster:shared-db
+
+- - neutron-api:shared-db
+  - percona-cluster:shared-db
+
+- - aodh:shared-db
+  - percona-cluster:shared-db
+
+- - gnocchi:shared-db
+  - percona-cluster:shared-db
+
+- - glance:shared-db
+  - percona-cluster:shared-db
+
+- - designate:shared-db
+  - percona-cluster:shared-db
+
+- - cinder:shared-db
+  - percona-cluster:shared-db
+
+- - placement:shared-db
+  - percona-cluster:shared-db

--- a/tests/series-upgrade/tests/bundles/trusty-to-xenial-mitaka-ha.yaml.j2
+++ b/tests/series-upgrade/tests/bundles/trusty-to-xenial-mitaka-ha.yaml.j2
@@ -1,0 +1,606 @@
+# This is the trusty-mitaka to xenial-mitaka series upgrade bundle.
+#
+# TODO:
+#         - Add SSL everywhere
+#         - Add HA everywhere
+
+variables:
+  openstack-origin: &openstack-origin cloud:trusty-mitaka
+
+series: trusty
+
+applications:
+
+  aodh:
+    charm: cs:~openstack-charmers-next/aodh
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP00 }}
+    constraints: mem=1024
+
+  aodh-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+#  barbican:
+#    charm: cs:~openstack-charmers-next/barbican
+#    num_units: 1
+#    options:
+#      openstack-origin: *openstack-origin
+#    constraints: mem=1024
+
+  ceilometer:
+    charm: cs:~openstack-charmers-next/ceilometer
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP01 }}
+    constraints: mem=1024
+
+  ceilometer-agent:
+    charm: cs:~openstack-charmers-next/ceilometer-agent
+
+  ceilometer-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  ceph-mon:
+    charm: cs:~openstack-charmers-next/ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *openstack-origin
+
+  ceph-osd:
+    charm: cs:~openstack-charmers-next/ceph-osd
+    num_units: 3
+    options:
+      source: *openstack-origin
+    constraints: mem=1024
+    storage:
+      osd-devices:  cinder,40G
+
+  cinder:
+    charm: cs:~openstack-charmers-next/cinder
+    num_units: 3
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP02 }}
+    constraints: mem=1024
+
+  cinder-ceph:
+    charm: cs:~openstack-charmers-next/cinder-ceph
+
+  cinder-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  dashboard-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  designate:
+    charm: cs:~openstack-charmers-next/designate
+    num_units: 3
+    options:
+      nameservers: ns1.mojo.serverstack.com.
+      neutron-domain: ""
+      neutron-domain-email: ""
+      nova-domain: ""
+      nova-domain-email: ""
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP03 }}
+    constraints: mem=1024
+
+  designate-bind:
+    charm: cs:~openstack-charmers-next/designate-bind
+    num_units: 3
+
+  designate-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+
+  etcd:
+    series: bionic
+    #charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
+    num_units: 3
+    options:
+      channel: 3.1/stable
+
+  glance:
+    charm: cs:~openstack-charmers-next/glance
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP04 }}
+    constraints: mem=1024
+
+  glance-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  gnocchi:
+    charm: cs:~openstack-charmers-next/gnocchi
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP05 }}
+
+  gnocchi-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  heat:
+    charm: cs:~openstack-charmers-next/heat
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP06 }}
+
+  heat-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  keystone:
+    charm: cs:~openstack-charmers-next/keystone
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP07 }}
+    constraints: mem=1024
+
+  keystone-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  memcached:
+    charm: cs:memcached
+    num_units: 1
+
+  percona-cluster:
+    charm: cs:~openstack-charmers-next/percona-cluster
+    constraints: mem=3072M
+    num_units: 1
+    options:
+      #vip: {{ TEST_VIP08 }}
+      source: *openstack-origin
+
+#  percona-hacluster:
+#    charm: cs:~openstack-charmers-next/hacluster
+#    num_units: 0
+#    options:
+#      cluster_count: 3
+
+  neutron-api:
+    charm: cs:~openstack-charmers-next/neutron-api
+    num_units: 3
+    options:
+      manage-neutron-plugin-legacy-mode: True
+      dns-domain: mojo.serverstack.
+      enable-ml2-dns: true
+      flat-network-providers: physnet1
+      ipv4-ptr-zone-prefix-size: 24
+      neutron-security-groups: true
+      openstack-origin: *openstack-origin
+      reverse-dns-lookup: true
+      vip: {{ TEST_VIP09 }}
+    constraints: mem=1024
+
+  neutron-gateway:
+    charm: cs:~openstack-charmers-next/neutron-gateway
+    num_units: 1
+    options:
+      bridge-mappings: physnet1:br-ex
+      instance-mtu: 1300
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+
+  neutron-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  neutron-openvswitch:
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+
+  nova-cc-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  nova-cloud-controller:
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    num_units: 3
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP10 }}
+    constraints: mem=2048
+
+  nova-compute:
+    charm: cs:~openstack-charmers-next/nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+
+  openstack-dashboard:
+    charm: cs:~openstack-charmers-next/openstack-dashboard
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP11 }}
+    constraints: mem=1024
+
+  rabbitmq-server:
+    charm: cs:~openstack-charmers-next/rabbitmq-server
+    num_units: 1
+    options:
+      source: *openstack-origin
+    constraints: mem=4096
+
+  swift-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  swift-proxy:
+    charm: cs:~openstack-charmers-next/swift-proxy
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      vip: {{ TEST_VIP12 }}
+      zone-assignment: manual
+    constraints: mem=1024
+
+  swift-storage-z1:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+
+  swift-storage-z2:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+
+  swift-storage-z3:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+
+  vault:
+    charm: cs:~openstack-charmers-next/vault
+    num_units: 3
+    options:
+      ssl-ca: {{ TEST_CACERT }}
+      ssl-cert: {{ TEST_CERT }}
+      ssl-key: {{ TEST_KEY }}
+      vip: {{ TEST_VIP13 }}
+    constraints: mem=1024
+
+  vault-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+relations:
+
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+
+- - nova-cloud-controller:image-service
+  - glance:image-service
+
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+
+- - nova-cloud-controller:memcache
+  - memcached:cache
+
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+
+- - nova-compute:image-service
+  - glance:image-service
+
+- - nova-compute:ceph
+  - ceph-mon:client
+
+- - glance:identity-service
+  - keystone:identity-service
+
+- - glance:ceph
+  - ceph-mon:client
+
+- - glance:image-service
+  - cinder:image-service
+
+- - glance:amqp
+  - rabbitmq-server:amqp
+
+- - cinder:amqp
+  - rabbitmq-server:amqp
+
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+
+- - cinder:identity-service
+  - keystone:identity-service
+
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+
+- - cinder-ceph:ceph
+  - ceph-mon:client
+
+- - neutron-gateway:quantum-network-service
+  - nova-cloud-controller:quantum-network-service
+
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+
+- - swift-proxy:identity-service
+  - keystone:identity-service
+
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+
+- - heat:identity-service
+  - keystone:identity-service
+
+- - heat:amqp
+  - rabbitmq-server:amqp
+
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch:neutron-plugin-api
+
+- - neutron-api:identity-service
+  - keystone:identity-service
+
+- - neutron-api:neutron-plugin-api
+  - neutron-gateway:neutron-plugin-api
+
+- - neutron-openvswitch:neutron-plugin
+  - nova-compute:neutron-plugin
+
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+
+- - ceph-osd:mon
+  - ceph-mon:osd
+
+- - keystone:certificates
+  - vault:certificates
+
+- - neutron-api:certificates
+  - vault:certificates
+
+- - nova-cloud-controller:certificates
+  - vault:certificates
+
+- - swift-proxy:certificates
+  - vault:certificates
+
+- - cinder:certificates
+  - vault:certificates
+
+- - glance:certificates
+  - vault:certificates
+
+- - rabbitmq-server:certificates
+  - vault:certificates
+
+- - heat:certificates
+  - vault:certificates
+
+- - keystone:ha
+  - keystone-hacluster:ha
+
+- - nova-cloud-controller:ha
+  - nova-cc-hacluster:ha
+
+- - cinder:ha
+  - cinder-hacluster:ha
+
+- - glance:ha
+  - glance-hacluster:ha
+
+- - openstack-dashboard:ha
+  - dashboard-hacluster:ha
+
+- - swift-proxy:ha
+  - swift-hacluster:ha
+
+- - neutron-api:ha
+  - neutron-hacluster:ha
+
+- - heat:ha
+  - heat-hacluster:ha
+
+- - vault:ha
+  - vault-hacluster:ha
+
+- - etcd:certificates
+  - easyrsa:client
+
+- - etcd:db
+  - vault:etcd
+
+- - aodh:amqp
+  - rabbitmq-server:amqp
+
+- - aodh:identity-service
+  - keystone:identity-service
+
+- - aodh:ha
+  - aodh-hacluster:ha
+
+- - designate:identity-service
+  - keystone:identity-service
+
+- - designate:amqp
+  - rabbitmq-server:amqp
+
+- - designate:dns-backend
+  - designate-bind:dns-backend
+
+- - designate:coordinator-memcached
+  - memcached:cache
+
+- - designate:dnsaas
+  - neutron-api:external-dns
+
+- - designate:ha
+  - designate-hacluster:ha
+
+- - aodh:certificates
+  - vault:certificates
+
+- - designate:certificates
+  - vault:certificates
+
+- - gnocchi:storage-ceph
+  - ceph-mon:client
+
+- - gnocchi:amqp
+  - rabbitmq-server:amqp
+
+- - gnocchi:coordinator-memcached
+  - memcached:cache
+
+- - gnocchi:metric-service
+  - ceilometer:metric-service
+
+- - gnocchi:identity-service
+  - keystone:identity-service
+
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+
+- - gnocchi:certificates
+  - vault:certificates
+
+- - ceilometer:identity-credentials
+  - keystone:identity-credentials
+
+- - ceilometer:identity-notifications
+  - keystone:identity-notifications
+
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
+
+- - ceilometer-agent:nova-ceilometer
+  - nova-compute:nova-ceilometer
+
+- - ceilometer-agent:ceilometer-service
+  - ceilometer:ceilometer-service
+
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
+
+- - ceilometer:ha
+  - ceilometer-hacluster:ha
+
+- - gnocchi:ha
+  - gnocchi-hacluster:ha
+
+- - ceilometer:certificates
+  - vault:certificates
+
+- - vault:shared-db
+  - percona-cluster:shared-db
+
+- - keystone:shared-db
+  - percona-cluster:shared-db
+
+- - heat:shared-db
+  - percona-cluster:shared-db
+
+- - nova-cloud-controller:shared-db
+  - percona-cluster:shared-db
+
+- - neutron-api:shared-db
+  - percona-cluster:shared-db
+
+- - aodh:shared-db
+  - percona-cluster:shared-db
+
+- - gnocchi:shared-db
+  - percona-cluster:shared-db
+
+- - glance:shared-db
+  - percona-cluster:shared-db
+
+- - designate:shared-db
+  - percona-cluster:shared-db
+
+- - cinder:shared-db
+  - percona-cluster:shared-db

--- a/tests/series-upgrade/tests/bundles/xenial-to-bionic-queens-ha.yaml.j2
+++ b/tests/series-upgrade/tests/bundles/xenial-to-bionic-queens-ha.yaml.j2
@@ -1,0 +1,648 @@
+# This is the xenial-queens to bionic-queens series upgrade bundle.
+#
+# TODO:
+#         - Add SSL everywhere
+#         - Add HA everywhere
+
+variables:
+  openstack-origin: &openstack-origin cloud:xenial-queens
+
+series: xenial
+
+applications:
+
+  aodh:
+    charm: cs:~openstack-charmers-next/aodh
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP00 }}
+    constraints: mem=1024
+
+  aodh-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+#  barbican:
+#    charm: cs:~openstack-charmers-next/barbican
+#    num_units: 1
+#    options:
+#      openstack-origin: *openstack-origin
+#    constraints: mem=1024
+
+  ceilometer:
+    charm: cs:~openstack-charmers-next/ceilometer
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP01 }}
+    constraints: mem=1024
+
+  ceilometer-agent:
+    charm: cs:~openstack-charmers-next/ceilometer-agent
+
+  ceilometer-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  ceph-mon:
+    charm: cs:~openstack-charmers-next/ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *openstack-origin
+
+  ceph-osd:
+    charm: cs:~openstack-charmers-next/ceph-osd
+    num_units: 3
+    options:
+      source: *openstack-origin
+    constraints: mem=1024
+    storage:
+      osd-devices:  cinder,40G
+
+  cinder:
+    charm: cs:~openstack-charmers-next/cinder
+    num_units: 3
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP02 }}
+    constraints: mem=1024
+
+  cinder-ceph:
+    charm: cs:~openstack-charmers-next/cinder-ceph
+
+  cinder-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  dashboard-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  designate:
+    charm: cs:~openstack-charmers-next/designate
+    num_units: 3
+    options:
+      nameservers: ns1.mojo.serverstack.com.
+      neutron-domain: ""
+      neutron-domain-email: ""
+      nova-domain: ""
+      nova-domain-email: ""
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP03 }}
+    constraints: mem=1024
+
+  designate-bind:
+    charm: cs:~openstack-charmers-next/designate-bind
+    num_units: 3
+
+  designate-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+
+  etcd:
+    series: bionic
+    #charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
+    num_units: 3
+    options:
+      channel: 3.1/stable
+
+  glance:
+    charm: cs:~openstack-charmers-next/glance
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP04 }}
+    constraints: mem=1024
+
+  glance-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  gnocchi:
+    charm: cs:~openstack-charmers-next/gnocchi
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP05 }}
+
+  gnocchi-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  heat:
+    charm: cs:~openstack-charmers-next/heat
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP06 }}
+
+  heat-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  keystone:
+    charm: cs:~openstack-charmers-next/keystone
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP07 }}
+    constraints: mem=1024
+
+  keystone-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  memcached:
+    charm: cs:memcached
+    num_units: 1
+
+  percona-cluster:
+    charm: cs:~openstack-charmers-next/percona-cluster
+    constraints: mem=3072M
+    num_units: 1
+    options:
+      #vip: {{ TEST_VIP08 }}
+      source: *openstack-origin
+
+#  percona-hacluster:
+#    charm: cs:~openstack-charmers-next/hacluster
+#    num_units: 0
+#    options:
+#      cluster_count: 3
+
+  neutron-api:
+    charm: cs:~openstack-charmers-next/neutron-api
+    num_units: 3
+    options:
+      manage-neutron-plugin-legacy-mode: True
+      dns-domain: mojo.serverstack.
+      enable-ml2-dns: true
+      flat-network-providers: physnet1
+      ipv4-ptr-zone-prefix-size: 24
+      neutron-security-groups: true
+      openstack-origin: *openstack-origin
+      reverse-dns-lookup: true
+      vip: {{ TEST_VIP09 }}
+    constraints: mem=1024
+
+  neutron-gateway:
+    charm: cs:~openstack-charmers-next/neutron-gateway
+    num_units: 1
+    options:
+      bridge-mappings: physnet1:br-ex
+      instance-mtu: 1300
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+
+  neutron-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  neutron-openvswitch:
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+
+#  placement:
+#    charm: cs:~openstack-charmers-next/placement
+#    num_units: 3
+#    options:
+#      openstack-origin: *openstack-origin
+#      vip: {{ TEST_VIP14 }}
+
+#  placement-hacluster:
+#    charm: cs:~openstack-charmers-next/hacluster
+#    options:
+#      cluster_count: 3
+#      corosync_transport: unicast
+
+  nova-cc-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  nova-cloud-controller:
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    num_units: 3
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP10 }}
+    constraints: mem=2048
+
+  nova-compute:
+    charm: cs:~openstack-charmers-next/nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+
+  openstack-dashboard:
+    charm: cs:~openstack-charmers-next/openstack-dashboard
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP11 }}
+    constraints: mem=1024
+
+  rabbitmq-server:
+    charm: cs:~openstack-charmers-next/rabbitmq-server
+    num_units: 1
+    options:
+      source: *openstack-origin
+    constraints: mem=4096
+
+  swift-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+  swift-proxy:
+    charm: cs:~openstack-charmers-next/swift-proxy
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      vip: {{ TEST_VIP12 }}
+      zone-assignment: manual
+    constraints: mem=1024
+
+  swift-storage-z1:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+
+  swift-storage-z2:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+
+  swift-storage-z3:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+
+  vault:
+    charm: cs:~openstack-charmers-next/vault
+    num_units: 3
+    options:
+      ssl-ca: {{ TEST_CACERT }}
+      ssl-cert: {{ TEST_CERT }}
+      ssl-key: {{ TEST_KEY }}
+      vip: {{ TEST_VIP13 }}
+    constraints: mem=1024
+
+  vault-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+
+relations:
+#- - placement:certificates
+#  - vault:certificates
+
+#- - placement:ha
+#  - placement-hacluster:ha
+
+#- - placement:identity-service
+#  - keystone:identity-service
+
+#- - placement:amqp
+#  - rabbitmq-server:amqp
+
+#- - nova-cloud-controller:placement
+#  - placement:placement
+
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+
+- - nova-cloud-controller:image-service
+  - glance:image-service
+
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+
+- - nova-cloud-controller:memcache
+  - memcached:cache
+
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+
+- - nova-compute:image-service
+  - glance:image-service
+
+- - nova-compute:ceph
+  - ceph-mon:client
+
+- - glance:identity-service
+  - keystone:identity-service
+
+- - glance:ceph
+  - ceph-mon:client
+
+- - glance:image-service
+  - cinder:image-service
+
+- - glance:amqp
+  - rabbitmq-server:amqp
+
+- - cinder:amqp
+  - rabbitmq-server:amqp
+
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+
+- - cinder:identity-service
+  - keystone:identity-service
+
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+
+- - cinder-ceph:ceph
+  - ceph-mon:client
+
+- - neutron-gateway:quantum-network-service
+  - nova-cloud-controller:quantum-network-service
+
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+
+- - swift-proxy:identity-service
+  - keystone:identity-service
+
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+
+- - heat:identity-service
+  - keystone:identity-service
+
+- - heat:amqp
+  - rabbitmq-server:amqp
+
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch:neutron-plugin-api
+
+- - neutron-api:identity-service
+  - keystone:identity-service
+
+- - neutron-api:neutron-plugin-api
+  - neutron-gateway:neutron-plugin-api
+
+- - neutron-openvswitch:neutron-plugin
+  - nova-compute:neutron-plugin
+
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+
+- - ceph-osd:mon
+  - ceph-mon:osd
+
+- - keystone:certificates
+  - vault:certificates
+
+- - neutron-api:certificates
+  - vault:certificates
+
+- - nova-cloud-controller:certificates
+  - vault:certificates
+
+- - swift-proxy:certificates
+  - vault:certificates
+
+- - cinder:certificates
+  - vault:certificates
+
+- - glance:certificates
+  - vault:certificates
+
+- - rabbitmq-server:certificates
+  - vault:certificates
+
+- - heat:certificates
+  - vault:certificates
+
+- - keystone:ha
+  - keystone-hacluster:ha
+
+- - nova-cloud-controller:ha
+  - nova-cc-hacluster:ha
+
+- - cinder:ha
+  - cinder-hacluster:ha
+
+- - glance:ha
+  - glance-hacluster:ha
+
+- - openstack-dashboard:ha
+  - dashboard-hacluster:ha
+
+- - swift-proxy:ha
+  - swift-hacluster:ha
+
+- - neutron-api:ha
+  - neutron-hacluster:ha
+
+- - heat:ha
+  - heat-hacluster:ha
+
+- - vault:ha
+  - vault-hacluster:ha
+
+- - etcd:certificates
+  - easyrsa:client
+
+- - etcd:db
+  - vault:etcd
+
+- - aodh:amqp
+  - rabbitmq-server:amqp
+
+- - aodh:identity-service
+  - keystone:identity-service
+
+- - aodh:ha
+  - aodh-hacluster:ha
+
+- - designate:identity-service
+  - keystone:identity-service
+
+- - designate:amqp
+  - rabbitmq-server:amqp
+
+- - designate:dns-backend
+  - designate-bind:dns-backend
+
+- - designate:coordinator-memcached
+  - memcached:cache
+
+- - designate:dnsaas
+  - neutron-api:external-dns
+
+- - designate:ha
+  - designate-hacluster:ha
+
+- - aodh:certificates
+  - vault:certificates
+
+- - designate:certificates
+  - vault:certificates
+
+- - gnocchi:storage-ceph
+  - ceph-mon:client
+
+- - gnocchi:amqp
+  - rabbitmq-server:amqp
+
+- - gnocchi:coordinator-memcached
+  - memcached:cache
+
+- - gnocchi:metric-service
+  - ceilometer:metric-service
+
+- - gnocchi:identity-service
+  - keystone:identity-service
+
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+
+- - gnocchi:certificates
+  - vault:certificates
+
+- - ceilometer:identity-credentials
+  - keystone:identity-credentials
+
+- - ceilometer:identity-notifications
+  - keystone:identity-notifications
+
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
+
+- - ceilometer-agent:nova-ceilometer
+  - nova-compute:nova-ceilometer
+
+- - ceilometer-agent:ceilometer-service
+  - ceilometer:ceilometer-service
+
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
+
+- - ceilometer:ha
+  - ceilometer-hacluster:ha
+
+- - gnocchi:ha
+  - gnocchi-hacluster:ha
+
+- - ceilometer:certificates
+  - vault:certificates
+
+#- - barbican:amqp
+#  - rabbitmq-server:amqp
+
+#- - barbican:identity-service
+#  - keystone:identity-service
+
+#- - percona-cluster
+#  - percona-hacluster
+
+- - vault:shared-db
+  - percona-cluster:shared-db
+
+- - keystone:shared-db
+  - percona-cluster:shared-db
+
+#- - barbican:shared-db
+#  - percona-cluster:shared-db
+
+- - heat:shared-db
+  - percona-cluster:shared-db
+
+- - nova-cloud-controller:shared-db
+  - percona-cluster:shared-db
+
+- - neutron-api:shared-db
+  - percona-cluster:shared-db
+
+- - aodh:shared-db
+  - percona-cluster:shared-db
+
+- - gnocchi:shared-db
+  - percona-cluster:shared-db
+
+- - glance:shared-db
+  - percona-cluster:shared-db
+
+- - designate:shared-db
+  - percona-cluster:shared-db
+
+- - cinder:shared-db
+  - percona-cluster:shared-db
+
+#- - placement:shared-db
+#  - percona-cluster:shared-db

--- a/tests/series-upgrade/tests/bundles/xenial-to-bionic-queens-ha.yaml.j2
+++ b/tests/series-upgrade/tests/bundles/xenial-to-bionic-queens-ha.yaml.j2
@@ -25,13 +25,6 @@ applications:
       cluster_count: 3
       corosync_transport: unicast
 
-#  barbican:
-#    charm: cs:~openstack-charmers-next/barbican
-#    num_units: 1
-#    options:
-#      openstack-origin: *openstack-origin
-#    constraints: mem=1024
-
   ceilometer:
     charm: cs:~openstack-charmers-next/ceilometer
     num_units: 3
@@ -191,12 +184,6 @@ applications:
       #vip: {{ TEST_VIP08 }}
       source: *openstack-origin
 
-#  percona-hacluster:
-#    charm: cs:~openstack-charmers-next/hacluster
-#    num_units: 0
-#    options:
-#      cluster_count: 3
-
   neutron-api:
     charm: cs:~openstack-charmers-next/neutron-api
     num_units: 3
@@ -229,19 +216,6 @@ applications:
 
   neutron-openvswitch:
     charm: cs:~openstack-charmers-next/neutron-openvswitch
-
-#  placement:
-#    charm: cs:~openstack-charmers-next/placement
-#    num_units: 3
-#    options:
-#      openstack-origin: *openstack-origin
-#      vip: {{ TEST_VIP14 }}
-
-#  placement-hacluster:
-#    charm: cs:~openstack-charmers-next/hacluster
-#    options:
-#      cluster_count: 3
-#      corosync_transport: unicast
 
   nova-cc-hacluster:
     charm: cs:~openstack-charmers-next/hacluster
@@ -347,21 +321,6 @@ applications:
       corosync_transport: unicast
 
 relations:
-#- - placement:certificates
-#  - vault:certificates
-
-#- - placement:ha
-#  - placement-hacluster:ha
-
-#- - placement:identity-service
-#  - keystone:identity-service
-
-#- - placement:amqp
-#  - rabbitmq-server:amqp
-
-#- - nova-cloud-controller:placement
-#  - placement:placement
-
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp
 
@@ -602,23 +561,11 @@ relations:
 - - ceilometer:certificates
   - vault:certificates
 
-#- - barbican:amqp
-#  - rabbitmq-server:amqp
-
-#- - barbican:identity-service
-#  - keystone:identity-service
-
-#- - percona-cluster
-#  - percona-hacluster
-
 - - vault:shared-db
   - percona-cluster:shared-db
 
 - - keystone:shared-db
   - percona-cluster:shared-db
-
-#- - barbican:shared-db
-#  - percona-cluster:shared-db
 
 - - heat:shared-db
   - percona-cluster:shared-db
@@ -643,6 +590,3 @@ relations:
 
 - - cinder:shared-db
   - percona-cluster:shared-db
-
-#- - placement:shared-db
-#  - percona-cluster:shared-db

--- a/tests/series-upgrade/tests/tests.yaml
+++ b/tests/series-upgrade/tests/tests.yaml
@@ -1,0 +1,54 @@
+before_deploy:
+  - bionic-to-focal-ussuri-ha:
+    - zaza.openstack.configure.pre_deploy_certs.set_cidr_certs
+  - xenial-to-bionic-queens-ha:
+    - zaza.openstack.configure.pre_deploy_certs.set_cidr_certs
+  - trusty-to-xenial-mitaka-ha:
+    - zaza.openstack.configure.pre_deploy_certs.set_cidr_certs
+configure:
+  - bionic-to-focal-ussuri-ha:
+    - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
+    - zaza.openstack.charm_tests.vault.setup.auto_initialize
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_image
+    - zaza.openstack.charm_tests.glance.setup.add_lts_image
+    - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+    - zaza.openstack.charm_tests.nova.setup.create_flavors
+    - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+  - xenial-to-bionic-queens-ha:
+    - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
+    - zaza.openstack.charm_tests.vault.setup.auto_initialize
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_image
+    - zaza.openstack.charm_tests.glance.setup.add_lts_image
+    - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+    - zaza.openstack.charm_tests.nova.setup.create_flavors
+    - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+  - trusty-to-xenial-mitaka-ha:
+    - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
+    - zaza.openstack.charm_tests.vault.setup.auto_initialize
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_image
+    - zaza.openstack.charm_tests.glance.setup.add_lts_image
+    - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+    - zaza.openstack.charm_tests.nova.setup.create_flavors
+    - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+tests:
+  - bionic-to-focal-ussuri-ha:
+    - zaza.openstack.charm_tests.series_upgrade.parallel_tests.BionicFocalSeriesUpgrade
+  - xenial-to-bionic-queens-ha:
+    - zaza.openstack.charm_tests.series_upgrade.parallel_tests.XenialBionicSeriesUpgrade
+  - trusty-to-xenial-mitaka-ha:
+    - zaza.openstack.charm_tests.series_upgrade.parallel_tests.TrustyXenialSeriesUpgrade
+smoke_bundles:
+  - bionic-to-focal-ussuri-ha: bionic-to-focal-ussuri-ha
+  - xenial-to-bionic-queens-ha: xenial-to-bionic-queens-ha
+  - trusty-to-xenial-mitaka-ha: trusty-to-xenial-mitaka-ha
+target_deploy_status:
+  easyrsa:
+    workload-status-message: Certificate Authority connected.
+  etcd:
+    workload-status-message: Healthy
+  vault:
+    workload-status: blocked
+    workload-status-message: Vault needs to be initialized
+  ceilometer:
+    workload-status: blocked
+    workload-status-message: "Run the ceilometer-upgrade action on the leader to initialize ceilometer and gnocchi"

--- a/tests/shared/kitchen-sink-focal-victoria.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-victoria.yaml.j2
@@ -1,0 +1,538 @@
+
+variables:
+  openstack-origin: &openstack-origin cloud:focal-victoria
+
+series: focal
+applications:
+  aodh:
+    charm: cs:~openstack-charmers-next/aodh
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP00 }}
+    constraints: mem=1024
+  aodh-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  barbican:
+    charm: cs:~openstack-charmers-next/barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  ceilometer:
+    charm: cs:~openstack-charmers-next/ceilometer
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP01 }}
+    constraints: mem=1024
+  ceilometer-agent:
+    charm: cs:~openstack-charmers-next/ceilometer-agent
+  ceilometer-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  ceph-mon:
+    charm: cs:~openstack-charmers-next/ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *openstack-origin
+  ceph-osd:
+    charm: cs:~openstack-charmers-next/ceph-osd
+    num_units: 3
+    options:
+      source: *openstack-origin
+    constraints: mem=1024
+    storage:
+      osd-devices:  cinder,40G
+  cinder:
+    charm: cs:~openstack-charmers-next/cinder
+    num_units: 3
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP02 }}
+    constraints: mem=1024
+  cinder-ceph:
+    charm: cs:~openstack-charmers-next/cinder-ceph
+  cinder-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  dashboard-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  designate:
+    charm: cs:~openstack-charmers-next/designate
+    num_units: 3
+    options:
+      nameservers: ns1.mojo.serverstack.com.
+      neutron-domain: ""
+      neutron-domain-email: ""
+      nova-domain: ""
+      nova-domain-email: ""
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP03 }}
+    constraints: mem=1024
+  designate-bind:
+    charm: cs:~openstack-charmers-next/designate-bind
+    num_units: 3
+  designate-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+  etcd:
+    series: bionic
+    charm: cs:~containers/etcd-474
+    num_units: 3
+    options:
+      channel: 3.1/stable
+  glance:
+    charm: cs:~openstack-charmers-next/glance
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP04 }}
+    constraints: mem=1024
+  glance-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  gnocchi:
+    charm: cs:~openstack-charmers-next/gnocchi
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP05 }}
+  gnocchi-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  heat:
+    charm: cs:~openstack-charmers-next/heat
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP06 }}
+  heat-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  keystone:
+    charm: cs:~openstack-charmers-next/keystone
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP07 }}
+    constraints: mem=1024
+  keystone-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  memcached:
+    series: bionic
+    charm: cs:~memcached-team/memcached
+    num_units: 1
+  mysql-innodb-cluster:
+    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    constraints: mem=3072M
+    num_units: 3
+    options:
+      source: *openstack-origin
+  neutron-api:
+    charm: cs:~openstack-charmers-next/neutron-api
+    num_units: 3
+    options:
+      manage-neutron-plugin-legacy-mode: True
+      dns-domain: mojo.serverstack.
+      enable-ml2-dns: true
+      flat-network-providers: physnet1
+      ipv4-ptr-zone-prefix-size: 24
+      neutron-security-groups: true
+      openstack-origin: *openstack-origin
+      reverse-dns-lookup: true
+      vip: {{ TEST_VIP09 }}
+    constraints: mem=1024
+  neutron-gateway:
+    charm: cs:~openstack-charmers-next/neutron-gateway
+    num_units: 1
+    options:
+      bridge-mappings: physnet1:br-ex
+      instance-mtu: 1300
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+  neutron-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  neutron-openvswitch:
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+  placement:
+    charm: cs:~openstack-charmers-next/placement
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP14 }}
+  placement-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  nova-cc-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  nova-cloud-controller:
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    num_units: 3
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP10 }}
+    constraints: mem=2048
+  nova-compute:
+    charm: cs:~openstack-charmers-next/nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+  openstack-dashboard:
+    charm: cs:~openstack-charmers-next/openstack-dashboard
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP11 }}
+    constraints: mem=1024
+  rabbitmq-server:
+    charm: cs:~openstack-charmers-next/rabbitmq-server
+    num_units: 1
+    options:
+      source: *openstack-origin
+    constraints: mem=2048
+  swift-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  swift-proxy:
+    charm: cs:~openstack-charmers-next/swift-proxy
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      vip: {{ TEST_VIP12 }}
+      zone-assignment: manual
+    constraints: mem=1024
+  swift-storage-z1:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+  swift-storage-z2:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+  swift-storage-z3:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+  vault:
+    charm: cs:~openstack-charmers-next/vault
+    num_units: 3
+    options:
+      ssl-ca: {{ TEST_CACERT }}
+      ssl-cert: {{ TEST_CERT }}
+      ssl-key: {{ TEST_KEY }}
+      vip: {{ TEST_VIP13 }}
+    constraints: mem=1024
+  vault-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  vault-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  keystone-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  barbican-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  heat-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  nova-cloud-controller-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  neutron-api-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  aodh-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  gnocchi-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  glance-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  designate-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  cinder-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  placement-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+relations:
+- - placement:certificates
+  - vault:certificates
+- - placement:ha
+  - placement-hacluster:ha
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:placement
+  - placement:placement
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-cloud-controller:memcache
+  - memcached:cache
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - neutron-gateway:quantum-network-service
+  - nova-cloud-controller:quantum-network-service
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - heat:identity-service
+  - keystone:identity-service
+- - heat:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch:neutron-plugin-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-api:neutron-plugin-api
+  - neutron-gateway:neutron-plugin-api
+- - neutron-openvswitch:neutron-plugin
+  - nova-compute:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - keystone:certificates
+  - vault:certificates
+- - neutron-api:certificates
+  - vault:certificates
+- - nova-cloud-controller:certificates
+  - vault:certificates
+- - swift-proxy:certificates
+  - vault:certificates
+- - cinder:certificates
+  - vault:certificates
+- - glance:certificates
+  - vault:certificates
+- - rabbitmq-server:certificates
+  - vault:certificates
+- - heat:certificates
+  - vault:certificates
+- - mysql-innodb-cluster:certificates
+  - vault:certificates
+- - keystone:ha
+  - keystone-hacluster:ha
+- - nova-cloud-controller:ha
+  - nova-cc-hacluster:ha
+- - cinder:ha
+  - cinder-hacluster:ha
+- - glance:ha
+  - glance-hacluster:ha
+- - openstack-dashboard:ha
+  - dashboard-hacluster:ha
+- - swift-proxy:ha
+  - swift-hacluster:ha
+- - neutron-api:ha
+  - neutron-hacluster:ha
+- - heat:ha
+  - heat-hacluster:ha
+- - vault:ha
+  - vault-hacluster:ha
+- - etcd:certificates
+  - easyrsa:client
+- - etcd:db
+  - vault:etcd
+- - aodh:amqp
+  - rabbitmq-server:amqp
+- - aodh:identity-service
+  - keystone:identity-service
+- - aodh:ha
+  - aodh-hacluster:ha
+- - designate:identity-service
+  - keystone:identity-service
+- - designate:amqp
+  - rabbitmq-server:amqp
+- - designate:dns-backend
+  - designate-bind:dns-backend
+- - designate:coordinator-memcached
+  - memcached:cache
+- - designate:dnsaas
+  - neutron-api:external-dns
+- - designate:ha
+  - designate-hacluster:ha
+- - aodh:certificates
+  - vault:certificates
+- - designate:certificates
+  - vault:certificates
+- - gnocchi:storage-ceph
+  - ceph-mon:client
+- - gnocchi:amqp
+  - rabbitmq-server:amqp
+- - gnocchi:coordinator-memcached
+  - memcached:cache
+- - gnocchi:metric-service
+  - ceilometer:metric-service
+- - gnocchi:identity-service
+  - keystone:identity-service
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - gnocchi:certificates
+  - vault:certificates
+- - ceilometer:identity-credentials
+  - keystone:identity-credentials
+- - ceilometer:identity-notifications
+  - keystone:identity-notifications
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
+- - ceilometer-agent:nova-ceilometer
+  - nova-compute:nova-ceilometer
+- - ceilometer-agent:ceilometer-service
+  - ceilometer:ceilometer-service
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
+- - ceilometer:ha
+  - ceilometer-hacluster:ha
+- - gnocchi:ha
+  - gnocchi-hacluster:ha
+- - ceilometer:certificates
+  - vault:certificates
+- - barbican:amqp
+  - rabbitmq-server:amqp
+- - barbican:identity-service
+  - keystone:identity-service
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - barbican:shared-db
+  - barbican-mysql-router:shared-db
+- - barbican-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - heat:shared-db
+  - heat-mysql-router:shared-db
+- - heat-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-cloud-controller:shared-db
+  - nova-cloud-controller-mysql-router:shared-db
+- - nova-cloud-controller-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-api:shared-db
+  - neutron-api-mysql-router:shared-db
+- - neutron-api-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - aodh:shared-db
+  - aodh-mysql-router:shared-db
+- - aodh-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - gnocchi:shared-db
+  - gnocchi-mysql-router:shared-db
+- - gnocchi-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - designate:shared-db
+  - designate-mysql-router:shared-db
+- - designate-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router

--- a/tests/shared/kitchen-sink-groovy-victoria.yaml.j2
+++ b/tests/shared/kitchen-sink-groovy-victoria.yaml.j2
@@ -1,0 +1,538 @@
+
+variables:
+  openstack-origin: &openstack-origin distro
+
+series: groovy
+applications:
+  aodh:
+    charm: cs:~openstack-charmers-next/aodh
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP00 }}
+    constraints: mem=1024
+  aodh-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  barbican:
+    charm: cs:~openstack-charmers-next/barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  ceilometer:
+    charm: cs:~openstack-charmers-next/ceilometer
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP01 }}
+    constraints: mem=1024
+  ceilometer-agent:
+    charm: cs:~openstack-charmers-next/ceilometer-agent
+  ceilometer-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  ceph-mon:
+    charm: cs:~openstack-charmers-next/ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *openstack-origin
+  ceph-osd:
+    charm: cs:~openstack-charmers-next/ceph-osd
+    num_units: 3
+    options:
+      source: *openstack-origin
+    constraints: mem=1024
+    storage:
+      osd-devices:  cinder,40G
+  cinder:
+    charm: cs:~openstack-charmers-next/cinder
+    num_units: 3
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP02 }}
+    constraints: mem=1024
+  cinder-ceph:
+    charm: cs:~openstack-charmers-next/cinder-ceph
+  cinder-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  dashboard-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  designate:
+    charm: cs:~openstack-charmers-next/designate
+    num_units: 3
+    options:
+      nameservers: ns1.mojo.serverstack.com.
+      neutron-domain: ""
+      neutron-domain-email: ""
+      nova-domain: ""
+      nova-domain-email: ""
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP03 }}
+    constraints: mem=1024
+  designate-bind:
+    charm: cs:~openstack-charmers-next/designate-bind
+    num_units: 3
+  designate-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    num_units: 1
+  etcd:
+    series: bionic
+    charm: cs:~containers/etcd-474
+    num_units: 3
+    options:
+      channel: 3.1/stable
+  glance:
+    charm: cs:~openstack-charmers-next/glance
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP04 }}
+    constraints: mem=1024
+  glance-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  gnocchi:
+    charm: cs:~openstack-charmers-next/gnocchi
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP05 }}
+  gnocchi-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  heat:
+    charm: cs:~openstack-charmers-next/heat
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP06 }}
+  heat-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  keystone:
+    charm: cs:~openstack-charmers-next/keystone
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP07 }}
+    constraints: mem=1024
+  keystone-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  memcached:
+    series: bionic
+    charm: cs:~memcached-team/memcached
+    num_units: 1
+  mysql-innodb-cluster:
+    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    constraints: mem=3072M
+    num_units: 3
+    options:
+      source: *openstack-origin
+  neutron-api:
+    charm: cs:~openstack-charmers-next/neutron-api
+    num_units: 3
+    options:
+      manage-neutron-plugin-legacy-mode: True
+      dns-domain: mojo.serverstack.
+      enable-ml2-dns: true
+      flat-network-providers: physnet1
+      ipv4-ptr-zone-prefix-size: 24
+      neutron-security-groups: true
+      openstack-origin: *openstack-origin
+      reverse-dns-lookup: true
+      vip: {{ TEST_VIP09 }}
+    constraints: mem=1024
+  neutron-gateway:
+    charm: cs:~openstack-charmers-next/neutron-gateway
+    num_units: 1
+    options:
+      bridge-mappings: physnet1:br-ex
+      instance-mtu: 1300
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+  neutron-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  neutron-openvswitch:
+    charm: cs:~openstack-charmers-next/neutron-openvswitch
+  placement:
+    charm: cs:~openstack-charmers-next/placement
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP14 }}
+  placement-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  nova-cc-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  nova-cloud-controller:
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    num_units: 3
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP10 }}
+    constraints: mem=2048
+  nova-compute:
+    charm: cs:~openstack-charmers-next/nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+  openstack-dashboard:
+    charm: cs:~openstack-charmers-next/openstack-dashboard
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      vip: {{ TEST_VIP11 }}
+    constraints: mem=1024
+  rabbitmq-server:
+    charm: cs:~openstack-charmers-next/rabbitmq-server
+    num_units: 1
+    options:
+      source: *openstack-origin
+    constraints: mem=2048
+  swift-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  swift-proxy:
+    charm: cs:~openstack-charmers-next/swift-proxy
+    num_units: 3
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      vip: {{ TEST_VIP12 }}
+      zone-assignment: manual
+    constraints: mem=1024
+  swift-storage-z1:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+  swift-storage-z2:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+  swift-storage-z3:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    constraints: mem=1024
+    storage:
+      block-devices:  cinder,10G
+  vault:
+    charm: cs:~openstack-charmers-next/vault
+    num_units: 3
+    options:
+      ssl-ca: {{ TEST_CACERT }}
+      ssl-cert: {{ TEST_CERT }}
+      ssl-key: {{ TEST_KEY }}
+      vip: {{ TEST_VIP13 }}
+    constraints: mem=1024
+  vault-hacluster:
+    charm: cs:~openstack-charmers-next/hacluster
+    options:
+      cluster_count: 3
+      corosync_transport: unicast
+  vault-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  keystone-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  barbican-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  heat-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  nova-cloud-controller-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  neutron-api-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  aodh-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  gnocchi-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  glance-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  designate-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  cinder-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  placement-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+relations:
+- - placement:certificates
+  - vault:certificates
+- - placement:ha
+  - placement-hacluster:ha
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:placement
+  - placement:placement
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-cloud-controller:memcache
+  - memcached:cache
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - neutron-gateway:quantum-network-service
+  - nova-cloud-controller:quantum-network-service
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - heat:identity-service
+  - keystone:identity-service
+- - heat:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch:neutron-plugin-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-api:neutron-plugin-api
+  - neutron-gateway:neutron-plugin-api
+- - neutron-openvswitch:neutron-plugin
+  - nova-compute:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - keystone:certificates
+  - vault:certificates
+- - neutron-api:certificates
+  - vault:certificates
+- - nova-cloud-controller:certificates
+  - vault:certificates
+- - swift-proxy:certificates
+  - vault:certificates
+- - cinder:certificates
+  - vault:certificates
+- - glance:certificates
+  - vault:certificates
+- - rabbitmq-server:certificates
+  - vault:certificates
+- - heat:certificates
+  - vault:certificates
+- - mysql-innodb-cluster:certificates
+  - vault:certificates
+- - keystone:ha
+  - keystone-hacluster:ha
+- - nova-cloud-controller:ha
+  - nova-cc-hacluster:ha
+- - cinder:ha
+  - cinder-hacluster:ha
+- - glance:ha
+  - glance-hacluster:ha
+- - openstack-dashboard:ha
+  - dashboard-hacluster:ha
+- - swift-proxy:ha
+  - swift-hacluster:ha
+- - neutron-api:ha
+  - neutron-hacluster:ha
+- - heat:ha
+  - heat-hacluster:ha
+- - vault:ha
+  - vault-hacluster:ha
+- - etcd:certificates
+  - easyrsa:client
+- - etcd:db
+  - vault:etcd
+- - aodh:amqp
+  - rabbitmq-server:amqp
+- - aodh:identity-service
+  - keystone:identity-service
+- - aodh:ha
+  - aodh-hacluster:ha
+- - designate:identity-service
+  - keystone:identity-service
+- - designate:amqp
+  - rabbitmq-server:amqp
+- - designate:dns-backend
+  - designate-bind:dns-backend
+- - designate:coordinator-memcached
+  - memcached:cache
+- - designate:dnsaas
+  - neutron-api:external-dns
+- - designate:ha
+  - designate-hacluster:ha
+- - aodh:certificates
+  - vault:certificates
+- - designate:certificates
+  - vault:certificates
+- - gnocchi:storage-ceph
+  - ceph-mon:client
+- - gnocchi:amqp
+  - rabbitmq-server:amqp
+- - gnocchi:coordinator-memcached
+  - memcached:cache
+- - gnocchi:metric-service
+  - ceilometer:metric-service
+- - gnocchi:identity-service
+  - keystone:identity-service
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - gnocchi:certificates
+  - vault:certificates
+- - ceilometer:identity-credentials
+  - keystone:identity-credentials
+- - ceilometer:identity-notifications
+  - keystone:identity-notifications
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
+- - ceilometer-agent:nova-ceilometer
+  - nova-compute:nova-ceilometer
+- - ceilometer-agent:ceilometer-service
+  - ceilometer:ceilometer-service
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
+- - ceilometer:ha
+  - ceilometer-hacluster:ha
+- - gnocchi:ha
+  - gnocchi-hacluster:ha
+- - ceilometer:certificates
+  - vault:certificates
+- - barbican:amqp
+  - rabbitmq-server:amqp
+- - barbican:identity-service
+  - keystone:identity-service
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - barbican:shared-db
+  - barbican-mysql-router:shared-db
+- - barbican-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - heat:shared-db
+  - heat-mysql-router:shared-db
+- - heat-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-cloud-controller:shared-db
+  - nova-cloud-controller-mysql-router:shared-db
+- - nova-cloud-controller-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-api:shared-db
+  - neutron-api-mysql-router:shared-db
+- - neutron-api-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - aodh:shared-db
+  - aodh-mysql-router:shared-db
+- - aodh-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - gnocchi:shared-db
+  - gnocchi-mysql-router:shared-db
+- - gnocchi-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - designate:shared-db
+  - designate-mysql-router:shared-db
+- - designate-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,19 @@
 envlist = pep8
 skipsdist = True
 
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
+requires = pip < 20.3
+           virtualenv < 20.0
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.2.0
+
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
@@ -49,12 +62,14 @@ commands =
 [testenv:kitchen-sink-focal-ussuri]
 basepython = python3
 changedir = tests/kitchen-sink
+setenv = TEST_DEPLOY_TIMEOUT = 10000
 commands =
     functest-run-suite --keep-model --bundle kitchen-sink-focal-ussuri
 
 [testenv:vrrp-focal-ussuri]
 basepython = python3
 changedir = tests/vrrp
+setenv = TEST_DEPLOY_TIMEOUT = 10000
 commands =
     functest-run-suite --keep-model --bundle vrrp-focal-ussuri
 
@@ -72,6 +87,19 @@ setenv = TEST_DEPLOY_TIMEOUT = 10000
 commands =
     functest-run-suite --keep-model --bundle {posargs}
 
+[testenv:openstack-upgrade]
+basepython = python3
+changedir = tests/openstack-upgrade
+setenv = TEST_DEPLOY_TIMEOUT = 10000
+commands =
+    functest-run-suite --keep-model --bundle {posargs}
+
+[testenv:series-upgrade]
+basepython = python3
+changedir = tests/series-upgrade
+setenv = TEST_DEPLOY_TIMEOUT = 10000
+commands =
+    functest-run-suite --keep-model --bundle {posargs}
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
This adds series and openstack upgrade scenario tests (the equivalent of
the existing mojo tests) for focal, plus the start of the series upgrade
replacement tests for trusty->xenial and xenial->bionic.

tox.ini is upgraded to pin to < 20.3 to avoid the new pip resolver until
that piece of tech debt is resolved.

chardet is pinned to 3.0.4 due to some installation issues on xenial.
This is again tech debt that will be resolved with the pip resolver
work.