### PR TITLE
Use OVN for Octavia

### DIFF
--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/focal-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:~openstack-charmers-next/neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:~openstack-charmers-next/octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/focal-xena.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena.yaml
@@ -1,0 +1,453 @@
+variables:
+  source: &source cloud:focal-xena/proposed
+  openstack-origin: &openstack-origin cloud:focal-xena/proposed
+
+series: &series focal
+applications:
+  aodh:
+    charm: cs:aodh
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  aodh-mysql-router:
+    charm: cs:mysql-router
+  barbican:
+    charm: cs:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  barbican-mysql-router:
+    charm: cs:mysql-router
+  ceilometer:
+    charm: cs:ceilometer
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  ceilometer-agent:
+    charm: cs:ceilometer-agent
+  ceph-mon:
+    charm: cs:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+  ceph-osd:
+    charm: cs:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=1024
+  cinder:
+    charm: cs:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  cinder-ceph:
+    charm: cs:cinder-ceph
+  cinder-mysql-router:
+    charm: cs:mysql-router
+  designate:
+    charm: cs:designate
+    num_units: 1
+    options:
+      nameservers: ns1.ubuntu.com.
+      neutron-domain: serverstack.ubuntu.com.
+      neutron-domain-email: bob@serverstack.ubuntu.com
+      nova-domain: serverstack.ubuntu.com.
+      nova-domain-email: bob@serverstack.ubuntu.com
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  designate-bind:
+    charm: cs:designate-bind
+    num_units: 1
+  designate-mysql-router:
+    charm: cs:mysql-router
+  glance:
+    charm: cs:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  glance-mysql-router:
+    charm: cs:mysql-router
+  gnocchi:
+    charm: cs:gnocchi
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+  gnocchi-mysql-router:
+    charm: cs:mysql-router
+  heat:
+    charm: cs:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+  heat-mysql-router:
+    charm: cs:mysql-router
+  keystone:
+    charm: cs:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  keystone-mysql-router:
+    charm: cs:mysql-router
+  memcached:
+    charm: cs:~memcached-team/memcached
+    num_units: 1
+    constraints: mem=1024
+    # holding at bionic as memcached doesn't support focal yet
+    series: bionic
+  mysql-innodb-cluster:
+    charm: cs:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+  vault:
+    charm: cs:vault
+    num_units: 1
+  vault-mysql-router:
+    charm: cs:mysql-router
+  ovn-central:
+    charm: cs:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+  neutron-api-plugin-ovn:
+    charm: cs:neutron-api-plugin-ovn
+  ovn-chassis:
+    charm: cs:ovn-chassis
+  neutron-api:
+    charm: cs:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+  neutron-mysql-router:
+    charm: cs:mysql-router
+  nova-cloud-controller:
+    charm: cs:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+  nova-compute:
+    charm: cs:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+  nova-mysql-router:
+    charm: cs:mysql-router
+  openstack-dashboard:
+    charm: cs:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  placement:
+    charm: cs:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  placement-mysql-router:
+    charm: cs:mysql-router
+  rabbitmq-server:
+    charm: cs:rabbitmq-server
+    num_units: 1
+    options:
+      source: *source
+    constraints: mem=1024
+  swift-proxy:
+    charm: cs:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+  swift-storage-z1:
+    charm: cs:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+  swift-storage-z2:
+    charm: cs:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+  swift-storage-z3:
+    charm: cs:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+  octavia:
+    charm: cs:octavia
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      spare-pool-size: 2
+      loadbalancer-topology: 'ACTIVE_STANDBY'
+  octavia-mysql-router:
+    charm: cs:mysql-router
+  glance-simplestreams-sync:
+    charm: cs:glance-simplestreams-sync
+    num_units: 1
+    options:
+      source: ppa:simplestreams-dev/trunk
+      use_swift: true
+  octavia-diskimage-retrofit:
+    charm: cs:octavia-diskimage-retrofit
+    options:
+      amp-image-tag: 'octavia-amphora'
+      retrofit-uca-pocket: rocky
+      retrofit-series: bionic
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - ceilometer:identity-service
+  - keystone:identity-service
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
+- - ceilometer-agent:nova-ceilometer
+  - nova-compute:nova-ceilometer
+- - ceilometer-agent:ceilometer-service
+  - ceilometer:ceilometer-service
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
+- - heat:identity-service
+  - keystone:identity-service
+- - heat:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - aodh:amqp
+  - rabbitmq-server:amqp
+- - aodh:identity-service
+  - keystone:identity-service
+- - designate:identity-service
+  - keystone:identity-service
+- - designate:amqp
+  - rabbitmq-server:amqp
+- - designate:dns-backend
+  - designate-bind:dns-backend
+- - designate:coordinator-memcached
+  - memcached:cache
+- - gnocchi:storage-ceph
+  - ceph-mon:client
+- - gnocchi:amqp
+  - rabbitmq-server:amqp
+- - gnocchi:coordinator-memcached
+  - memcached:cache
+- - gnocchi:metric-service
+  - ceilometer:metric-service
+- - gnocchi:identity-service
+  - keystone:identity-service
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - ceilometer:identity-credentials
+  - keystone:identity-credentials
+- - designate:dnsaas
+  - neutron-api:external-dns
+- - barbican:amqp
+  - rabbitmq-server:amqp
+- - barbican:identity-service
+  - keystone:identity-service
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
+- - vault:certificates
+  - aodh:certificates
+- - vault:certificates
+  - barbican:certificates
+- - vault:certificates
+  - ceilometer:certificates
+- - vault:certificates
+  - designate:certificates
+- - vault:certificates
+  - gnocchi:certificates
+- - vault:certificates
+  - heat:certificates
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - swift-proxy:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - heat-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - aodh-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - designate-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - gnocchi-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - barbican-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - heat:shared-db
+  - heat-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - aodh:shared-db
+  - aodh-mysql-router:shared-db
+- - designate:shared-db
+  - designate-mysql-router:shared-db
+- - gnocchi:shared-db
+  - gnocchi-mysql-router:shared-db
+- - barbican:shared-db
+  - barbican-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - octavia-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - octavia-mysql-router:shared-db
+  - octavia:shared-db
+- - keystone:identity-service
+  - octavia:identity-service
+- - rabbitmq-server:amqp
+  - octavia:amqp
+- - neutron-api:neutron-load-balancer
+  - octavia:neutron-api
+- - glance-simplestreams-sync:juju-info
+  - octavia-diskimage-retrofit:juju-info
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - keystone:identity-credentials
+  - octavia-diskimage-retrofit:identity-credentials
+- - vault:certificates
+  - octavia:certificates
+- - vault:certificates
+  - octavia-diskimage-retrofit:certificates
+- - vault:certificates
+  - glance-simplestreams-sync:certificates

--- a/tests/distro-regression/tests/bundles/groovy-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/groovy-victoria.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/hirsute-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/hirsute-wallaby.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:~openstack-charmers-next/neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:~openstack-charmers-next/octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/impish-xena.yaml
+++ b/tests/distro-regression/tests/bundles/impish-xena.yaml
@@ -1,0 +1,453 @@
+variables:
+  source: &source proposed
+  openstack-origin: &openstack-origin distro-proposed
+
+series: &series impish
+applications:
+  aodh:
+    charm: cs:~openstack-charmers-next/aodh
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  aodh-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  barbican:
+    charm: cs:~openstack-charmers-next/barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  barbican-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  ceilometer:
+    charm: cs:~openstack-charmers-next/ceilometer
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  ceilometer-agent:
+    charm: cs:~openstack-charmers-next/ceilometer-agent
+  ceph-mon:
+    charm: cs:~openstack-charmers-next/ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+  ceph-osd:
+    charm: cs:~openstack-charmers-next/ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=1024
+  cinder:
+    charm: cs:~openstack-charmers-next/cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  cinder-ceph:
+    charm: cs:~openstack-charmers-next/cinder-ceph
+  cinder-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  designate:
+    charm: cs:~openstack-charmers-next/designate
+    num_units: 1
+    options:
+      nameservers: ns1.ubuntu.com.
+      neutron-domain: serverstack.ubuntu.com.
+      neutron-domain-email: bob@serverstack.ubuntu.com
+      nova-domain: serverstack.ubuntu.com.
+      nova-domain-email: bob@serverstack.ubuntu.com
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  designate-bind:
+    charm: cs:~openstack-charmers-next/designate-bind
+    num_units: 1
+  designate-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  glance:
+    charm: cs:~openstack-charmers-next/glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  glance-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  gnocchi:
+    charm: cs:~openstack-charmers-next/gnocchi
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+  gnocchi-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  heat:
+    charm: cs:~openstack-charmers-next/heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+  heat-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  keystone:
+    charm: cs:~openstack-charmers-next/keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  keystone-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  memcached:
+    charm: cs:~memcached-team/memcached
+    num_units: 1
+    constraints: mem=1024
+    # holding at bionic as memcached doesn't support focal yet
+    series: bionic
+  mysql-innodb-cluster:
+    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+  vault:
+    charm: cs:~openstack-charmers-next/vault
+    num_units: 1
+  vault-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  ovn-central:
+    charm: cs:~openstack-charmers-next/ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+  neutron-api-plugin-ovn:
+    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+  ovn-chassis:
+    charm: cs:~openstack-charmers-next/ovn-chassis
+  neutron-api:
+    charm: cs:~openstack-charmers-next/neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+  neutron-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  nova-cloud-controller:
+    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+  nova-compute:
+    charm: cs:~openstack-charmers-next/nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+  nova-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  openstack-dashboard:
+    charm: cs:~openstack-charmers-next/openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  placement:
+    charm: cs:~openstack-charmers-next/placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  placement-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  rabbitmq-server:
+    charm: cs:~openstack-charmers-next/rabbitmq-server
+    num_units: 1
+    options:
+      source: *source
+    constraints: mem=1024
+  swift-proxy:
+    charm: cs:~openstack-charmers-next/swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+  swift-storage-z1:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+  swift-storage-z2:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+  swift-storage-z3:
+    charm: cs:~openstack-charmers-next/swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+  octavia:
+    charm: cs:~openstack-charmers-next/octavia
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      spare-pool-size: 2
+      loadbalancer-topology: 'ACTIVE_STANDBY'
+  octavia-mysql-router:
+    charm: cs:~openstack-charmers-next/mysql-router
+  glance-simplestreams-sync:
+    charm: cs:~openstack-charmers-next/glance-simplestreams-sync
+    num_units: 1
+    options:
+      source: ppa:simplestreams-dev/trunk
+      use_swift: true
+  octavia-diskimage-retrofit:
+    charm: cs:~openstack-charmers-next/octavia-diskimage-retrofit
+    options:
+      amp-image-tag: 'octavia-amphora'
+      retrofit-uca-pocket: rocky
+      retrofit-series: bionic
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - ceilometer:identity-service
+  - keystone:identity-service
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
+- - ceilometer-agent:nova-ceilometer
+  - nova-compute:nova-ceilometer
+- - ceilometer-agent:ceilometer-service
+  - ceilometer:ceilometer-service
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
+- - heat:identity-service
+  - keystone:identity-service
+- - heat:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - aodh:amqp
+  - rabbitmq-server:amqp
+- - aodh:identity-service
+  - keystone:identity-service
+- - designate:identity-service
+  - keystone:identity-service
+- - designate:amqp
+  - rabbitmq-server:amqp
+- - designate:dns-backend
+  - designate-bind:dns-backend
+- - designate:coordinator-memcached
+  - memcached:cache
+- - gnocchi:storage-ceph
+  - ceph-mon:client
+- - gnocchi:amqp
+  - rabbitmq-server:amqp
+- - gnocchi:coordinator-memcached
+  - memcached:cache
+- - gnocchi:metric-service
+  - ceilometer:metric-service
+- - gnocchi:identity-service
+  - keystone:identity-service
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - ceilometer:identity-credentials
+  - keystone:identity-credentials
+- - designate:dnsaas
+  - neutron-api:external-dns
+- - barbican:amqp
+  - rabbitmq-server:amqp
+- - barbican:identity-service
+  - keystone:identity-service
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
+- - vault:certificates
+  - aodh:certificates
+- - vault:certificates
+  - barbican:certificates
+- - vault:certificates
+  - ceilometer:certificates
+- - vault:certificates
+  - designate:certificates
+- - vault:certificates
+  - gnocchi:certificates
+- - vault:certificates
+  - heat:certificates
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - swift-proxy:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - heat-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - aodh-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - designate-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - gnocchi-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - barbican-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - heat:shared-db
+  - heat-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - aodh:shared-db
+  - aodh-mysql-router:shared-db
+- - designate:shared-db
+  - designate-mysql-router:shared-db
+- - gnocchi:shared-db
+  - gnocchi-mysql-router:shared-db
+- - barbican:shared-db
+  - barbican-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - octavia-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - octavia-mysql-router:shared-db
+  - octavia:shared-db
+- - keystone:identity-service
+  - octavia:identity-service
+- - rabbitmq-server:amqp
+  - octavia:amqp
+- - neutron-api:neutron-load-balancer
+  - octavia:neutron-api
+- - glance-simplestreams-sync:juju-info
+  - octavia-diskimage-retrofit:juju-info
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - keystone:identity-credentials
+  - octavia-diskimage-retrofit:identity-credentials
+- - vault:certificates
+  - octavia:certificates
+- - vault:certificates
+  - octavia-diskimage-retrofit:certificates
+- - vault:certificates
+  - glance-simplestreams-sync:certificates

--- a/tests/distro-regression/tests/tests.yaml
+++ b/tests/distro-regression/tests/tests.yaml
@@ -15,6 +15,8 @@ smoke_bundles:
   - keystone_v3_smoke_focal: groovy-victoria
   - keystone_v3_smoke_focal: focal-wallaby
   - keystone_v3_smoke_focal: hirsute-wallaby
+  - keystone_v3_smoke_focal: focal-xena
+  - keystone_v3_smoke_focal: impish-xena
 configure:
   - keystone_v2_smoke:
     - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
@@ -117,6 +119,7 @@ tests_options:
     - trusty-mitaka
     - groovy-victoria
     - hirsute-wallaby
+    - impish-xena
 target_deploy_status:
   ceilometer:
     workload-status: blocked


### PR DESCRIPTION
focal ussuri and later bundles where using a mix of OVN and OVS
drivers for networking with neutron-openvswitch deployed alongside
Octavia.

Drop use of neutron-openvswitch and make deployments pure OVN.