### PR TITLE
Minor openstack upgrade improvements

### DIFF
--- a/tests/series-upgrade/tests/bundles/bionic-to-focal-ussuri-ha.yaml.j2
+++ b/tests/series-upgrade/tests/bundles/bionic-to-focal-ussuri-ha.yaml.j2
@@ -126,7 +126,6 @@ applications:
 
   etcd:
     series: bionic
-    #charm: cs:~containers/etcd-474
     charm: cs:~containers/etcd
     num_units: 3
     options:

--- a/tests/series-upgrade/tests/bundles/trusty-to-xenial-mitaka-ha.yaml.j2
+++ b/tests/series-upgrade/tests/bundles/trusty-to-xenial-mitaka-ha.yaml.j2
@@ -119,7 +119,6 @@ applications:
 
   etcd:
     series: bionic
-    #charm: cs:~containers/etcd-474
     charm: cs:~containers/etcd
     num_units: 3
     options:

--- a/tests/series-upgrade/tests/bundles/xenial-to-bionic-queens-ha.yaml.j2
+++ b/tests/series-upgrade/tests/bundles/xenial-to-bionic-queens-ha.yaml.j2
@@ -112,7 +112,6 @@ applications:
 
   etcd:
     series: bionic
-    #charm: cs:~containers/etcd-474
     charm: cs:~containers/etcd
     num_units: 3
     options:

--- a/tests/shared/kitchen-sink-focal-ussuri-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-ussuri-stable.yaml.j2
@@ -95,7 +95,7 @@ applications:
     num_units: 1
   etcd:
     series: bionic
-    charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
     num_units: 3
     options:
       channel: 3.1/stable

--- a/tests/shared/kitchen-sink-focal-ussuri-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-ussuri-stable.yaml.j2
@@ -217,7 +217,7 @@ applications:
       enable-resize: true
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
-    constraints: mem=4096
+    constraints: mem=4096M cores=4
   openstack-dashboard:
     charm: cs:~openstack-charmers/openstack-dashboard
     num_units: 3

--- a/tests/shared/kitchen-sink-focal-ussuri.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-ussuri.yaml.j2
@@ -216,7 +216,7 @@ applications:
       enable-resize: true
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
-    constraints: mem=4096
+    constraints: mem=4096M cores=4
   openstack-dashboard:
     charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 3

--- a/tests/shared/kitchen-sink-focal-ussuri.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-ussuri.yaml.j2
@@ -95,7 +95,7 @@ applications:
     num_units: 1
   etcd:
     series: bionic
-    charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
     num_units: 3
     options:
       channel: 3.1/stable

--- a/tests/shared/kitchen-sink-focal-victoria-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-victoria-stable.yaml.j2
@@ -95,7 +95,7 @@ applications:
     num_units: 1
   etcd:
     series: bionic
-    charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
     num_units: 3
     options:
       channel: 3.1/stable

--- a/tests/shared/kitchen-sink-focal-victoria-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-victoria-stable.yaml.j2
@@ -217,7 +217,7 @@ applications:
       enable-resize: true
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
-    constraints: mem=4096
+    constraints: mem=4096M cores=4
   openstack-dashboard:
     charm: cs:~openstack-charmers/openstack-dashboard
     num_units: 3

--- a/tests/shared/kitchen-sink-focal-victoria.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-victoria.yaml.j2
@@ -96,7 +96,7 @@ applications:
     num_units: 1
   etcd:
     series: bionic
-    charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
     num_units: 3
     options:
       channel: 3.1/stable

--- a/tests/shared/kitchen-sink-focal-victoria.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-victoria.yaml.j2
@@ -217,7 +217,7 @@ applications:
       enable-resize: true
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
-    constraints: mem=4096
+    constraints: mem=4096M cores=4
   openstack-dashboard:
     charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 3

--- a/tests/shared/kitchen-sink-focal-wallaby-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-wallaby-stable.yaml.j2
@@ -95,7 +95,7 @@ applications:
     num_units: 1
   etcd:
     series: bionic
-    charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
     num_units: 3
     options:
       channel: 3.1/stable

--- a/tests/shared/kitchen-sink-focal-wallaby-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-wallaby-stable.yaml.j2
@@ -217,7 +217,7 @@ applications:
       enable-resize: true
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
-    constraints: mem=4096
+    constraints: mem=4096M cores=4
   openstack-dashboard:
     charm: cs:~openstack-charmers/openstack-dashboard
     num_units: 3

--- a/tests/shared/kitchen-sink-focal-wallaby.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-wallaby.yaml.j2
@@ -96,7 +96,7 @@ applications:
     num_units: 1
   etcd:
     series: bionic
-    charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
     num_units: 3
     options:
       channel: 3.1/stable

--- a/tests/shared/kitchen-sink-focal-wallaby.yaml.j2
+++ b/tests/shared/kitchen-sink-focal-wallaby.yaml.j2
@@ -217,7 +217,7 @@ applications:
       enable-resize: true
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
-    constraints: mem=4096
+    constraints: mem=4096M cores=4
   openstack-dashboard:
     charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 3

--- a/tests/shared/kitchen-sink-groovy-victoria-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-groovy-victoria-stable.yaml.j2
@@ -95,7 +95,7 @@ applications:
     num_units: 1
   etcd:
     series: bionic
-    charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
     num_units: 3
     options:
       channel: 3.1/stable

--- a/tests/shared/kitchen-sink-groovy-victoria-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-groovy-victoria-stable.yaml.j2
@@ -217,7 +217,7 @@ applications:
       enable-resize: true
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
-    constraints: mem=4096
+    constraints: mem=4096M cores=4
   openstack-dashboard:
     charm: cs:~openstack-charmers/openstack-dashboard
     num_units: 3

--- a/tests/shared/kitchen-sink-groovy-victoria.yaml.j2
+++ b/tests/shared/kitchen-sink-groovy-victoria.yaml.j2
@@ -96,7 +96,7 @@ applications:
     num_units: 1
   etcd:
     series: bionic
-    charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
     num_units: 3
     options:
       channel: 3.1/stable

--- a/tests/shared/kitchen-sink-groovy-victoria.yaml.j2
+++ b/tests/shared/kitchen-sink-groovy-victoria.yaml.j2
@@ -217,7 +217,7 @@ applications:
       enable-resize: true
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
-    constraints: mem=4096
+    constraints: mem=4096M cores=4
   openstack-dashboard:
     charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 3

--- a/tests/shared/kitchen-sink-hirsute-wallaby-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-hirsute-wallaby-stable.yaml.j2
@@ -95,7 +95,7 @@ applications:
     num_units: 1
   etcd:
     series: bionic
-    charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
     num_units: 3
     options:
       channel: 3.1/stable

--- a/tests/shared/kitchen-sink-hirsute-wallaby-stable.yaml.j2
+++ b/tests/shared/kitchen-sink-hirsute-wallaby-stable.yaml.j2
@@ -217,7 +217,7 @@ applications:
       enable-resize: true
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
-    constraints: mem=4096
+    constraints: mem=4096M cores=4
   openstack-dashboard:
     charm: cs:~openstack-charmers/openstack-dashboard
     num_units: 3

--- a/tests/shared/kitchen-sink-hirsute-wallaby.yaml.j2
+++ b/tests/shared/kitchen-sink-hirsute-wallaby.yaml.j2
@@ -96,7 +96,7 @@ applications:
     num_units: 1
   etcd:
     series: bionic
-    charm: cs:~containers/etcd-474
+    charm: cs:~containers/etcd
     num_units: 3
     options:
       channel: 3.1/stable

--- a/tests/shared/kitchen-sink-hirsute-wallaby.yaml.j2
+++ b/tests/shared/kitchen-sink-hirsute-wallaby.yaml.j2
@@ -217,7 +217,7 @@ applications:
       enable-resize: true
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
-    constraints: mem=4096
+    constraints: mem=4096M cores=4
   openstack-dashboard:
     charm: cs:~openstack-charmers-next/openstack-dashboard
     num_units: 3


### PR DESCRIPTION
See commit messages for details.

Validated locally:

```
$ tox -e openstack-upgrade kitchen-sink-focal-ussuri
[...]
2021-08-05 14:23:44 [INFO] Ran 3 tests in 3916.002s
2021-08-05 14:23:44 [INFO] OK
2021-08-05 14:23:44 [INFO] Events:
  Before Deploy zaza.openstack.configure.pre_deploy_certs.set_cidr_certs:
    Start: 1628164245.7251055
    Finish: 1628164246.2612362
    Elapsed Time: 0.5361306667327881
    PCT Of Run Time: 1
  Configure zaza.openstack.charm_tests.ceilometer.setup.basic_setup:
    Start: 1628166745.504081
    Finish: 1628166780.3108542
    Elapsed Time: 34.80677318572998
    PCT Of Run Time: 1
  Configure zaza.openstack.charm_tests.glance.setup.add_cirros_alt_image:
    Start: 1628168936.5348752
    Finish: 1628168967.0404077
    Elapsed Time: 30.50553250312805
    PCT Of Run Time: 1
  Configure zaza.openstack.charm_tests.glance.setup.add_cirros_image:
    Start: 1628168886.1648955
    Finish: 1628168936.53481
    Elapsed Time: 50.369914531707764
    PCT Of Run Time: 1
  Configure zaza.openstack.charm_tests.glance.setup.add_lts_image:
    Start: 1628168967.0404677
    Finish: 1628169019.2281268
    Elapsed Time: 52.18765902519226
    PCT Of Run Time: 1
  Configure zaza.openstack.charm_tests.keystone.setup.add_demo_user:
    Start: 1628169297.27924
    Finish: 1628169382.530206
    Elapsed Time: 85.25096607208252
    PCT Of Run Time: 1
  Configure zaza.openstack.charm_tests.keystone.setup.add_tempest_roles:
    Start: 1628169382.5302794
    Finish: 1628169417.9646626
    Elapsed Time: 35.434383153915405
    PCT Of Run Time: 1
  Configure zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network:
    Start: 1628169019.2291899
    Finish: 1628169224.6324692
    Elapsed Time: 205.4032793045044
    PCT Of Run Time: 3
  Configure zaza.openstack.charm_tests.nova.setup.create_flavors:
    Start: 1628169224.6325412
    Finish: 1628169256.151187
    Elapsed Time: 31.518645763397217
    PCT Of Run Time: 1
  Configure zaza.openstack.charm_tests.nova.setup.manage_ssh_key:
    Start: 1628169256.1512232
    Finish: 1628169297.2791984
    Elapsed Time: 41.12797522544861
    PCT Of Run Time: 1
  Configure zaza.openstack.charm_tests.tempest.setup.render_tempest_config_keystone_v3:
    Start: 1628169417.964701
    Finish: 1628169507.5331545
    Elapsed Time: 89.56845355033875
    PCT Of Run Time: 1
  Configure zaza.openstack.charm_tests.vault.setup.auto_initialize:
    Start: 1628166780.3108778
    Finish: 1628168886.1648757
    Elapsed Time: 2105.8539979457855
    PCT Of Run Time: 23
  Deploy Bundle:
    Start: 1628164246.2613552
    Finish: 1628164348.4610739
    Elapsed Time: 102.19971871376038
    PCT Of Run Time: 2
  Prepare Environment:
    Start: 1628164240.755726
    Finish: 1628164245.724916
    Elapsed Time: 4.969189882278442
    PCT Of Run Time: 1
  Test zaza.openstack.charm_tests.openstack_upgrade.tests.OpenStackUpgradeTestsFocalUssuri:
    Start: 1628169508.420289
    Finish: 1628173424.4243004
    Elapsed Time: 3916.0040113925934
    PCT Of Run Time: 43
  Test zaza.openstack.charm_tests.openstack_upgrade.tests.WaitForMySQL:
    Start: 1628169507.5333443
    Finish: 1628169508.4202583
    Elapsed Time: 0.8869140148162842
    PCT Of Run Time: 1
  Wait for Deployment:
    Start: 1628164348.46142
    Finish: 1628166745.139467
    Elapsed Time: 2396.678046941757
    PCT Of Run Time: 27
Metadata: {}

_____________________________________________________________________________________________________ summary _____________________________________________________________________________________________________
  openstack-upgrade: commands succeeded
  congratulations :)
```