### PR TITLE
Use OVN for Octavia

### DIFF
--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/focal-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:~openstack-charmers-next/neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:~openstack-charmers-next/octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/focal-xena.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:~openstack-charmers-next/neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:~openstack-charmers-next/octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/groovy-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/groovy-victoria.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/hirsute-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/hirsute-wallaby.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:~openstack-charmers-next/neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:~openstack-charmers-next/octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service

--- a/tests/distro-regression/tests/bundles/impish-xena.yaml
+++ b/tests/distro-regression/tests/bundles/impish-xena.yaml
@@ -213,13 +213,6 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
-  neutron-openvswitch-octavia:
-    charm: cs:~openstack-charmers-next/neutron-openvswitch
-    num_units: 0
-    options:
-      debug: True
-      prevent-arp-spoofing: False
-      firewall-driver: openvswitch
   octavia:
     charm: cs:~openstack-charmers-next/octavia
     num_units: 1
@@ -356,6 +349,10 @@ relations:
   - vault:certificates
 - - ovn-chassis:ovsdb
   - ovn-central:ovsdb
+- - ovn-chassis:ovsdb-subordinate
+  - octavia:ovsdb-subordinate
+- - ovn-central:ovsdb-cms
+  - octavia:ovsdb-cms
 - - vault:certificates
   - aodh:certificates
 - - vault:certificates
@@ -442,12 +439,6 @@ relations:
   - octavia:amqp
 - - neutron-api:neutron-load-balancer
   - octavia:neutron-api
-- - rabbitmq-server:amqp
-  - neutron-openvswitch-octavia:amqp
-- - neutron-api:neutron-plugin-api
-  - neutron-openvswitch-octavia:neutron-plugin-api
-- - neutron-openvswitch-octavia:neutron-plugin
-  - octavia:neutron-openvswitch
 - - glance-simplestreams-sync:juju-info
   - octavia-diskimage-retrofit:juju-info
 - - keystone:identity-service


### PR DESCRIPTION
focal ussuri and later bundles where using a mix of OVN and OVS
drivers for networking with neutron-openvswitch deployed alongside
Octavia.

Drop use of neutron-openvswitch and make deployments pure OVN.

Co-authored-by: James Page <james.page@ubuntu.com>