### PR TITLE
Pin paramiko < 2.9.0 for distro tempest tests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 chardet==3.0.4
+paramiko<2.9.0  # tempest tests fail to ssh into instances with 2.9.1
 git+https://opendev.org/openstack/tempest.git#egg=tempest;python_version>='3.6'
 tempest;python_version<'3.6'
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza


### PR DESCRIPTION
The distro tempest tests that ssh to guests fail due to public
key authentication failure with paramiko 2.9.1.

This change pins paramiko to 2.8.1, similar to the current
upper-constraints for openstack:
https://github.com/openstack/requirements/blob/master/upper-constraints.txt#L178