### PR TITLE
Update concurrency to two

### DIFF
--- a/osci.yaml
+++ b/osci.yaml
@@ -1,6 +1,6 @@
 - semaphore:
     name: distro-regression
-    max: 1
+    max: 2
 - project:
     periodic-weekly:
       jobs:


### PR DESCRIPTION
These jobs are queued up on Saturday at 4 UTC, having a slightly
higher concurrency should have negligible effect on other users of
the cloud.