### PR TITLE
Use charmhub for distro regression bundles

### DIFF
--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -5,58 +5,69 @@ variables:
 series: &series focal
 applications:
   aodh:
-    charm: cs:aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   aodh-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   barbican:
-    charm: cs:barbican
+    charm: ch:barbican
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   barbican-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   ceilometer:
-    charm: cs:ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   ceilometer-agent:
-    charm: cs:ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: ussuri/edge
   ceph-mon:
-    charm: cs:ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
       source: *source
     constraints: mem=1024
+    channel: octopus/edge
   ceph-osd:
-    charm: cs:ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       source: *source
     storage:
       osd-devices: cinder,10G
     constraints: mem=1024
+    channel: octopus/edge
   cinder:
-    charm: cs:cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   cinder-ceph:
-    charm: cs:cinder-ceph
+    charm: ch:cinder-ceph
+    channel: ussuri/edge
   cinder-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   designate:
-    charm: cs:designate
+    charm: ch:designate
     num_units: 1
     options:
       nameservers: ns1.ubuntu.com.
@@ -66,68 +77,85 @@ applications:
       nova-domain-email: bob@serverstack.ubuntu.com
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   designate-bind:
-    charm: cs:designate-bind
+    charm: ch:designate-bind
     num_units: 1
+    channel: ussuri/edge
   designate-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance:
-    charm: cs:glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   glance-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   gnocchi:
-    charm: cs:gnocchi
+    charm: ch:gnocchi
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: ussuri/edge
   gnocchi-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   heat:
-    charm: cs:heat
+    charm: ch:heat
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: ussuri/edge
   heat-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   keystone:
-    charm: cs:keystone
+    charm: ch:keystone
     num_units: 1
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   keystone-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   memcached:
-    charm: cs:~memcached-team/memcached
+    charm: ch:memcached
     num_units: 1
     constraints: mem=1024
     # holding at bionic as memcached doesn't support focal yet
     series: bionic
   mysql-innodb-cluster:
-    charm: cs:mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     constraints: mem=4096
+    channel: 8.0.19/edge
   vault:
-    charm: cs:vault
+    charm: ch:vault
     num_units: 1
+    channel: 1.7/stable
   vault-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   ovn-central:
-    charm: cs:ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
+    channel: 20.03/edge
   neutron-api-plugin-ovn:
-    charm: cs:neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: ussuri/edge
   ovn-chassis:
-    charm: cs:ovn-chassis
+    charm: ch:ovn-chassis
+    channel: 20.03/edge
   neutron-api:
-    charm: cs:neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -137,17 +165,20 @@ applications:
       enable-qos: true
       enable-vlan-trunking: true
     constraints: mem=1024
+    channel: ussuri/edge
   neutron-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   nova-cloud-controller:
-    charm: cs:nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
     constraints: mem=2048
+    channel: ussuri/edge
   nova-compute:
-    charm: cs:nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       enable-live-migration: true
@@ -155,30 +186,36 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: ussuri/edge
   nova-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   openstack-dashboard:
-    charm: cs:openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   placement:
-    charm: cs:placement
+    charm: ch:placement
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   placement-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   rabbitmq-server:
-    charm: cs:rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     options:
       source: *source
     constraints: mem=1024
+    channel: 3.8/edge
   swift-proxy:
-    charm: cs:swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -186,8 +223,9 @@ applications:
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
       zone-assignment: manual
     constraints: mem=1024
+    channel: ussuri/edge
   swift-storage-z1:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -195,8 +233,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: ussuri/edge
   swift-storage-z2:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -204,8 +243,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: ussuri/edge
   swift-storage-z3:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -213,27 +253,32 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: ussuri/edge
   octavia:
-    charm: cs:octavia
+    charm: ch:octavia
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    channel: ussuri/edge
   octavia-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance-simplestreams-sync:
-    charm: cs:glance-simplestreams-sync
+    charm: ch:glance-simplestreams-sync
     num_units: 1
     options:
       use_swift: true
     constraints: root-disk=8G
+    channel: ussuri/edge
   octavia-diskimage-retrofit:
-    charm: cs:octavia-diskimage-retrofit
+    charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-uca-pocket: rocky
       retrofit-series: bionic
+    channel: ussuri/edge
 relations:
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -5,58 +5,69 @@ variables:
 series: &series focal
 applications:
   aodh:
-    charm: cs:aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: victoria/edge
   aodh-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   barbican:
-    charm: cs:barbican
+    charm: ch:barbican
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: victoria/edge
   barbican-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   ceilometer:
-    charm: cs:ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: victoria/edge
   ceilometer-agent:
-    charm: cs:ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: victoria/edge
   ceph-mon:
-    charm: cs:ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
       source: *source
     constraints: mem=1024
+    channel: octopus/edge
   ceph-osd:
-    charm: cs:ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       source: *source
     storage:
       osd-devices: cinder,10G
     constraints: mem=1024
+    channel: octopus/edge
   cinder:
-    charm: cs:cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: victoria/edge
   cinder-ceph:
-    charm: cs:cinder-ceph
+    charm: ch:cinder-ceph
+    channel: victoria/edge
   cinder-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   designate:
-    charm: cs:designate
+    charm: ch:designate
     num_units: 1
     options:
       nameservers: ns1.ubuntu.com.
@@ -66,68 +77,85 @@ applications:
       nova-domain-email: bob@serverstack.ubuntu.com
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: victoria/edge
   designate-bind:
-    charm: cs:designate-bind
+    charm: ch:designate-bind
     num_units: 1
+    channel: victoria/edge
   designate-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance:
-    charm: cs:glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: victoria/edge
   glance-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   gnocchi:
-    charm: cs:gnocchi
+    charm: ch:gnocchi
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: victoria/edge
   gnocchi-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   heat:
-    charm: cs:heat
+    charm: ch:heat
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: victoria/edge
   heat-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   keystone:
-    charm: cs:keystone
+    charm: ch:keystone
     num_units: 1
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: victoria/edge
   keystone-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   memcached:
-    charm: cs:~memcached-team/memcached
+    charm: ch:memcached
     num_units: 1
     constraints: mem=1024
     # holding at bionic as memcached doesn't support focal yet
     series: bionic
   mysql-innodb-cluster:
-    charm: cs:mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     constraints: mem=4096
+    channel: 8.0.19/edge
   vault:
-    charm: cs:vault
+    charm: ch:vault
     num_units: 1
+    channel: 1.7/stable
   vault-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   ovn-central:
-    charm: cs:ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
+    channel: 20.03/edge
   neutron-api-plugin-ovn:
-    charm: cs:neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: victoria/edge
   ovn-chassis:
-    charm: cs:ovn-chassis
+    charm: ch:ovn-chassis
+    channel: 20.03/edge
   neutron-api:
-    charm: cs:neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -137,17 +165,20 @@ applications:
       enable-qos: true
       enable-vlan-trunking: true
     constraints: mem=1024
+    channel: victoria/edge
   neutron-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   nova-cloud-controller:
-    charm: cs:nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
     constraints: mem=2048
+    channel: victoria/edge
   nova-compute:
-    charm: cs:nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       enable-live-migration: true
@@ -155,30 +186,36 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: victoria/edge
   nova-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   openstack-dashboard:
-    charm: cs:openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: victoria/edge
   placement:
-    charm: cs:placement
+    charm: ch:placement
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: victoria/edge
   placement-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   rabbitmq-server:
-    charm: cs:rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     options:
       source: *source
     constraints: mem=1024
+    channel: 3.8/edge
   swift-proxy:
-    charm: cs:swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -186,8 +223,9 @@ applications:
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
       zone-assignment: manual
     constraints: mem=1024
+    channel: victoria/edge
   swift-storage-z1:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -195,8 +233,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: victoria/edge
   swift-storage-z2:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -204,8 +243,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: victoria/edge
   swift-storage-z3:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -213,27 +253,32 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: victoria/edge
   octavia:
-    charm: cs:octavia
+    charm: ch:octavia
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    channel: victoria/edge
   octavia-mysql-router:
-    charm: cs:mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance-simplestreams-sync:
-    charm: cs:glance-simplestreams-sync
+    charm: ch:glance-simplestreams-sync
     num_units: 1
     options:
       use_swift: true
     constraints: root-disk=8G
+    channel: victoria/edge
   octavia-diskimage-retrofit:
-    charm: cs:octavia-diskimage-retrofit
+    charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-uca-pocket: rocky
       retrofit-series: bionic
+    channel: victoria/edge
 relations:
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp

--- a/tests/distro-regression/tests/bundles/focal-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby.yaml
@@ -5,58 +5,69 @@ variables:
 series: &series focal
 applications:
   aodh:
-    charm: cs:~openstack-charmers-next/aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: wallaby/edge
   aodh-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   barbican:
-    charm: cs:~openstack-charmers-next/barbican
+    charm: ch:barbican
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: wallaby/edge
   barbican-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   ceilometer:
-    charm: cs:~openstack-charmers-next/ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: wallaby/edge
   ceilometer-agent:
-    charm: cs:~openstack-charmers-next/ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: wallaby/edge
   ceph-mon:
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
       source: *source
     constraints: mem=1024
+    channel: pacific/edge
   ceph-osd:
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       source: *source
     storage:
       osd-devices: cinder,10G
     constraints: mem=1024
+    channel: pacific/edge
   cinder:
-    charm: cs:~openstack-charmers-next/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: wallaby/edge
   cinder-ceph:
-    charm: cs:~openstack-charmers-next/cinder-ceph
+    charm: ch:cinder-ceph
+    channel: wallaby/edge
   cinder-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   designate:
-    charm: cs:~openstack-charmers-next/designate
+    charm: ch:designate
     num_units: 1
     options:
       nameservers: ns1.ubuntu.com.
@@ -66,68 +77,85 @@ applications:
       nova-domain-email: bob@serverstack.ubuntu.com
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: wallaby/edge
   designate-bind:
-    charm: cs:~openstack-charmers-next/designate-bind
+    charm: ch:designate-bind
     num_units: 1
+    channel: wallaby/edge
   designate-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   glance:
-    charm: cs:~openstack-charmers-next/glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: wallaby/edge
   glance-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   gnocchi:
-    charm: cs:~openstack-charmers-next/gnocchi
+    charm: ch:gnocchi
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: wallaby/edge
   gnocchi-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   heat:
-    charm: cs:~openstack-charmers-next/heat
+    charm: ch:heat
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: wallaby/edge
   heat-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   keystone:
-    charm: cs:~openstack-charmers-next/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: wallaby/edge
   keystone-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   memcached:
-    charm: cs:~memcached-team/memcached
+    charm: ch:memcached
     num_units: 1
     constraints: mem=1024
     # holding at bionic as memcached doesn't support focal yet
     series: bionic
   mysql-innodb-cluster:
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     constraints: mem=4096
+    channel: latest/edge
   vault:
-    charm: cs:~openstack-charmers-next/vault
+    charm: ch:vault
     num_units: 1
+    channel: 1.7/stable
   vault-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   ovn-central:
-    charm: cs:~openstack-charmers-next/ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
+    channel: 20.12/edge
   neutron-api-plugin-ovn:
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: wallaby/edge
   ovn-chassis:
-    charm: cs:~openstack-charmers-next/ovn-chassis
+    charm: ch:ovn-chassis
+    channel: 20.12/edge
   neutron-api:
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -137,17 +165,20 @@ applications:
       enable-qos: true
       enable-vlan-trunking: true
     constraints: mem=1024
+    channel: wallaby/edge
   neutron-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   nova-cloud-controller:
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
     constraints: mem=2048
+    channel: wallaby/edge
   nova-compute:
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       enable-live-migration: true
@@ -155,30 +186,36 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: wallaby/edge
   nova-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   openstack-dashboard:
-    charm: cs:~openstack-charmers-next/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: wallaby/edge
   placement:
-    charm: cs:~openstack-charmers-next/placement
+    charm: ch:placement
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: wallaby/edge
   placement-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   rabbitmq-server:
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     options:
       source: *source
     constraints: mem=1024
+    channel: 3.8/edge
   swift-proxy:
-    charm: cs:~openstack-charmers-next/swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -186,8 +223,9 @@ applications:
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
       zone-assignment: manual
     constraints: mem=1024
+    channel: wallaby/edge
   swift-storage-z1:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -195,8 +233,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: wallaby/edge
   swift-storage-z2:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -204,8 +243,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: wallaby/edge
   swift-storage-z3:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -213,27 +253,32 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: wallaby/edge
   octavia:
-    charm: cs:~openstack-charmers-next/octavia
+    charm: ch:octavia
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    channel: wallaby/edge
   octavia-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: latest/edge
   glance-simplestreams-sync:
-    charm: cs:~openstack-charmers-next/glance-simplestreams-sync
+    charm: ch:glance-simplestreams-sync
     num_units: 1
     options:
       use_swift: true
     constraints: root-disk=8G
+    channel: wallaby/edge
   octavia-diskimage-retrofit:
-    charm: cs:~openstack-charmers-next/octavia-diskimage-retrofit
+    charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-uca-pocket: rocky
       retrofit-series: bionic
+    channel: wallaby/edge
 relations:
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp

--- a/tests/distro-regression/tests/bundles/focal-xena.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena.yaml
@@ -5,58 +5,69 @@ variables:
 series: &series focal
 applications:
   aodh:
-    charm: cs:~openstack-charmers-next/aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   aodh-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   barbican:
-    charm: cs:~openstack-charmers-next/barbican
+    charm: ch:barbican
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   barbican-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   ceilometer:
-    charm: cs:~openstack-charmers-next/ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   ceilometer-agent:
-    charm: cs:~openstack-charmers-next/ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: xena/edge
   ceph-mon:
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
       source: *source
     constraints: mem=1024
+    channel: pacific/edge
   ceph-osd:
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       source: *source
     storage:
       osd-devices: cinder,10G
     constraints: mem=1024
+    channel: pacific/edge
   cinder:
-    charm: cs:~openstack-charmers-next/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   cinder-ceph:
-    charm: cs:~openstack-charmers-next/cinder-ceph
+    charm: ch:cinder-ceph
+    channel: xena/edge
   cinder-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   designate:
-    charm: cs:~openstack-charmers-next/designate
+    charm: ch:designate
     num_units: 1
     options:
       nameservers: ns1.ubuntu.com.
@@ -66,68 +77,85 @@ applications:
       nova-domain-email: bob@serverstack.ubuntu.com
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   designate-bind:
-    charm: cs:~openstack-charmers-next/designate-bind
+    charm: ch:designate-bind
     num_units: 1
+    channel: xena/edge
   designate-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance:
-    charm: cs:~openstack-charmers-next/glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   glance-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   gnocchi:
-    charm: cs:~openstack-charmers-next/gnocchi
+    charm: ch:gnocchi
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: xena/edge
   gnocchi-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   heat:
-    charm: cs:~openstack-charmers-next/heat
+    charm: ch:heat
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: xena/edge
   heat-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   keystone:
-    charm: cs:~openstack-charmers-next/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   keystone-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   memcached:
-    charm: cs:~memcached-team/memcached
+    charm: ch:memcached
     num_units: 1
     constraints: mem=1024
     # holding at bionic as memcached doesn't support focal yet
     series: bionic
   mysql-innodb-cluster:
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     constraints: mem=4096
+    channel: 8.0.19/edge
   vault:
-    charm: cs:~openstack-charmers-next/vault
+    charm: ch:vault
     num_units: 1
+    channel: 1.7/stable
   vault-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   ovn-central:
-    charm: cs:~openstack-charmers-next/ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
+    channel: 21.09/edge
   neutron-api-plugin-ovn:
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: xena/edge
   ovn-chassis:
-    charm: cs:~openstack-charmers-next/ovn-chassis
+    charm: ch:ovn-chassis
+    channel: 21.09/edge
   neutron-api:
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -137,17 +165,20 @@ applications:
       enable-qos: true
       enable-vlan-trunking: true
     constraints: mem=1024
+    channel: xena/edge
   neutron-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   nova-cloud-controller:
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
     constraints: mem=2048
+    channel: xena/edge
   nova-compute:
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       enable-live-migration: true
@@ -155,30 +186,36 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: xena/edge
   nova-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   openstack-dashboard:
-    charm: cs:~openstack-charmers-next/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   placement:
-    charm: cs:~openstack-charmers-next/placement
+    charm: ch:placement
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   placement-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   rabbitmq-server:
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     options:
       source: *source
     constraints: mem=1024
+    channel: 3.8/edge
   swift-proxy:
-    charm: cs:~openstack-charmers-next/swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -186,8 +223,9 @@ applications:
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
       zone-assignment: manual
     constraints: mem=1024
+    channel: xena/edge
   swift-storage-z1:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -195,8 +233,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: xena/edge
   swift-storage-z2:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -204,8 +243,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: xena/edge
   swift-storage-z3:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -213,27 +253,32 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: xena/edge
   octavia:
-    charm: cs:~openstack-charmers-next/octavia
+    charm: ch:octavia
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    channel: xena/edge
   octavia-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance-simplestreams-sync:
-    charm: cs:~openstack-charmers-next/glance-simplestreams-sync
+    charm: ch:glance-simplestreams-sync
     num_units: 1
     options:
       use_swift: true
     constraints: root-disk=8G
+    channel: xena/edge
   octavia-diskimage-retrofit:
-    charm: cs:~openstack-charmers-next/octavia-diskimage-retrofit
+    charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-uca-pocket: rocky
       retrofit-series: bionic
+    channel: xena/edge
 relations:
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp

--- a/tests/distro-regression/tests/bundles/impish-xena.yaml
+++ b/tests/distro-regression/tests/bundles/impish-xena.yaml
@@ -5,58 +5,69 @@ variables:
 series: &series impish
 applications:
   aodh:
-    charm: cs:~openstack-charmers-next/aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   aodh-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   barbican:
-    charm: cs:~openstack-charmers-next/barbican
+    charm: ch:barbican
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   barbican-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   ceilometer:
-    charm: cs:~openstack-charmers-next/ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   ceilometer-agent:
-    charm: cs:~openstack-charmers-next/ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: xena/edge
   ceph-mon:
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
       source: *source
     constraints: mem=1024
+    channel: pacific/edge
   ceph-osd:
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       source: *source
     storage:
       osd-devices: cinder,10G
     constraints: mem=1024
+    channel: pacific/edge
   cinder:
-    charm: cs:~openstack-charmers-next/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   cinder-ceph:
-    charm: cs:~openstack-charmers-next/cinder-ceph
+    charm: ch:cinder-ceph
+    channel: xena/edge
   cinder-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   designate:
-    charm: cs:~openstack-charmers-next/designate
+    charm: ch:designate
     num_units: 1
     options:
       nameservers: ns1.ubuntu.com.
@@ -66,68 +77,85 @@ applications:
       nova-domain-email: bob@serverstack.ubuntu.com
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   designate-bind:
-    charm: cs:~openstack-charmers-next/designate-bind
+    charm: ch:designate-bind
     num_units: 1
+    channel: xena/edge
   designate-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance:
-    charm: cs:~openstack-charmers-next/glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   glance-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   gnocchi:
-    charm: cs:~openstack-charmers-next/gnocchi
+    charm: ch:gnocchi
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: xena/edge
   gnocchi-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   heat:
-    charm: cs:~openstack-charmers-next/heat
+    charm: ch:heat
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: xena/edge
   heat-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   keystone:
-    charm: cs:~openstack-charmers-next/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   keystone-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   memcached:
-    charm: cs:~memcached-team/memcached
+    charm: ch:memcached
     num_units: 1
     constraints: mem=1024
     # holding at bionic as memcached doesn't support focal yet
     series: bionic
   mysql-innodb-cluster:
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     constraints: mem=4096
+    channel: 8.0.19/edge
   vault:
-    charm: cs:~openstack-charmers-next/vault
+    charm: ch:vault
     num_units: 1
+    channel: 1.7/stable
   vault-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   ovn-central:
-    charm: cs:~openstack-charmers-next/ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
+    channel: 21.09/edge
   neutron-api-plugin-ovn:
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: xena/edge
   ovn-chassis:
-    charm: cs:~openstack-charmers-next/ovn-chassis
+    charm: ch:ovn-chassis
+    channel: 21.09/edge
   neutron-api:
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       neutron-security-groups: true
@@ -137,17 +165,20 @@ applications:
       enable-qos: true
       enable-vlan-trunking: true
     constraints: mem=1024
+    channel: xena/edge
   neutron-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   nova-cloud-controller:
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
     constraints: mem=2048
+    channel: xena/edge
   nova-compute:
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       enable-live-migration: true
@@ -155,30 +186,36 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: xena/edge
   nova-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   openstack-dashboard:
-    charm: cs:~openstack-charmers-next/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   placement:
-    charm: cs:~openstack-charmers-next/placement
+    charm: ch:placement
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: xena/edge
   placement-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   rabbitmq-server:
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     options:
       source: *source
     constraints: mem=1024
+    channel: 3.8/edge
   swift-proxy:
-    charm: cs:~openstack-charmers-next/swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -186,8 +223,9 @@ applications:
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
       zone-assignment: manual
     constraints: mem=1024
+    channel: xena/edge
   swift-storage-z1:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -195,8 +233,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: xena/edge
   swift-storage-z2:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -204,8 +243,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: xena/edge
   swift-storage-z3:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -213,27 +253,32 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: xena/edge
   octavia:
-    charm: cs:~openstack-charmers-next/octavia
+    charm: ch:octavia
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    channel: xena/edge
   octavia-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
+    channel: 8.0.19/edge
   glance-simplestreams-sync:
-    charm: cs:~openstack-charmers-next/glance-simplestreams-sync
+    charm: ch:glance-simplestreams-sync
     num_units: 1
     options:
       use_swift: true
     constraints: root-disk=8G
+    channel: xena/edge
   octavia-diskimage-retrofit:
-    charm: cs:~openstack-charmers-next/octavia-diskimage-retrofit
+    charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-uca-pocket: rocky
       retrofit-series: bionic
+    channel: xena/edge
 relations:
 - - nova-cloud-controller:amqp
   - rabbitmq-server:amqp


### PR DESCRIPTION
This PR updates the bundles listed below to use charmhub (ch:) instead of charmstore (cs:), they use the edge risk channel, because it's where we can find the charms for all the tracks until the migration is completed for all the stable releases.