### PR TITLE
Skip oslo.log 4.8.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,7 @@
 chardet==3.0.4
 paramiko<2.9.0  # tempest tests fail to ssh into instances with 2.9.1
+# Skip 4.8.0 due to bug LP: #1972974
+oslo.log != 4.8.0
 git+https://opendev.org/openstack/tempest.git#egg=tempest;python_version>='3.6'
 tempest;python_version<'3.6'
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza


### PR DESCRIPTION
oslo.log 4.8.0 added by default the logging of global_request_id which
when not passed as an argument it will fail with the following error
message:

Traceback (most recent call last):
  File "/usr/lib/python3.8/logging/__init__.py", line 440, in format
    return self._format(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 436, in _format
    return self._fmt % record.__dict__
KeyError: 'global_request_id'

Tempest logs each http request, so this issue makes the terminal
littered with stacktraces.

See LP: #1972974 for more details.