### PR TITLE
Use _OS_PARAMS as an array in novarc scripts

### DIFF
--- a/scripts/novarc
+++ b/scripts/novarc
@@ -1,5 +1,5 @@
-_OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
-for param in $_OS_PARAMS; do
+_OS_PARAMS=($(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' '))
+for param in ${_OS_PARAMS[@]}; do
     if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
     if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param

--- a/scripts/novarc_unset_all
+++ b/scripts/novarc_unset_all
@@ -1,5 +1,5 @@
-_OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
-for param in $_OS_PARAMS; do
+_OS_PARAMS=($(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' '))
+for param in ${_OS_PARAMS[@]}; do
     unset $param
 done
 unset _OS_PARAMS

--- a/scripts/novarcv3_demo_project
+++ b/scripts/novarcv3_demo_project
@@ -1,5 +1,5 @@
-_OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
-for param in $_OS_PARAMS; do
+_OS_PARAMS=($(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' '))
+for param in ${_OS_PARAMS[@]}; do
     if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
     if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param

--- a/scripts/novarcv3_domain
+++ b/scripts/novarcv3_domain
@@ -1,5 +1,5 @@
-_OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
-for param in $_OS_PARAMS; do
+_OS_PARAMS=($(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' '))
+for param in ${_OS_PARAMS[@]}; do
     if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
     if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param

--- a/scripts/novarcv3_project
+++ b/scripts/novarcv3_project
@@ -1,5 +1,5 @@
-_OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
-for param in $_OS_PARAMS; do
+_OS_PARAMS=($(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' '))
+for param in ${_OS_PARAMS[@]}; do
     if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
     if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param

--- a/scripts/novarcv3_ssl_domain
+++ b/scripts/novarcv3_ssl_domain
@@ -1,5 +1,5 @@
-_OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
-for param in $_OS_PARAMS; do
+_OS_PARAMS=($(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' '))
+for param in ${_OS_PARAMS[@]}; do
     if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
     if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param

--- a/scripts/novarcv3_ssl_project
+++ b/scripts/novarcv3_ssl_project
@@ -1,5 +1,5 @@
-_OS_PARAMS=$(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' ')
-for param in $_OS_PARAMS; do
+_OS_PARAMS=($(env | awk 'BEGIN {FS="="} /^OS_/ {print $1;}' | paste -sd ' '))
+for param in ${_OS_PARAMS[@]}; do
     if [ "$param" = "OS_AUTH_PROTOCOL" ]; then continue; fi
     if [ "$param" = "OS_CACERT" ]; then continue; fi
     unset $param


### PR DESCRIPTION
ZHS doesn't deal properly with the space-delimited array of _OS_PARAMS
when sourcing novarc*.

```
novarc:unset:5: OS_AUTH_URL ...: invalid parameter name
```

This commit encloses the array so it will work fine in both bash and zsh
environments.