### PR TITLE
Distro bundle updates for charmhub, octavia-diskimage-retrofit, and various fixes

### DIFF
--- a/osci.yaml
+++ b/osci.yaml
@@ -4,7 +4,6 @@
 - project:
     periodic-weekly:
       jobs:
-      - cot_distro-regression_xenial-queens
       - cot_distro-regression_bionic-queens
       - cot_distro-regression_bionic-rocky
       - cot_distro-regression_bionic-stein
@@ -12,21 +11,17 @@
       - cot_distro-regression_bionic-ussuri
       - cot_distro-regression_focal-ussuri
       - cot_distro-regression_focal-victoria
-      - cot_distro-regression_groovy-victoria
       - cot_distro-regression_focal-wallaby
-      - cot_distro-regression_hirsute-wallaby
       - cot_distro-regression_focal-xena
-      - cot_distro-regression_impish-xena
+      - cot_distro-regression_focal-yoga
+      - cot_distro-regression_jammy-yoga
+      - cot_distro-regression_jammy-zed
+      - cot_distro-regression_kinetic-zed
 - job:
     name: cot-func-target
     parent: func-target
     semaphore: distro-regression
     abstract: true
-- job:
-    name: cot_distro-regression_xenial-queens
-    parent: cot-func-target
-    vars:
-      tox_extra_args: xenial-queens
 - job:
     name: cot_distro-regression_bionic-queens
     parent: cot-func-target
@@ -63,27 +58,32 @@
     vars:
       tox_extra_args: focal-victoria
 - job:
-    name: cot_distro-regression_groovy-victoria
-    parent: cot-func-target
-    vars:
-      tox_extra_args: groovy-victoria
-- job:
     name: cot_distro-regression_focal-wallaby
     parent: cot-func-target
     vars:
       tox_extra_args: focal-wallaby
-- job:
-    name: cot_distro-regression_hirsute-wallaby
-    parent: cot-func-target
-    vars:
-      tox_extra_args: hirsute-wallaby
 - job:
     name: cot_distro-regression_focal-xena
     parent: cot-func-target
     vars:
       tox_extra_args: focal-xena
 - job:
-    name: cot_distro-regression_impish-xena
+    name: cot_distro-regression_focal-yoga
     parent: cot-func-target
     vars:
-      tox_extra_args: impish-xena
+      tox_extra_args: focal-yoga
+- job:
+    name: cot_distro-regression_jammy-yoga
+    parent: cot-func-target
+    vars:
+      tox_extra_args: jammy-yoga
+- job:
+    name: cot_distro-regression_jammy-zed
+    parent: cot-func-target
+    vars:
+      tox_extra_args: jammy-zed
+- job:
+    name: cot_distro-regression_kinetic-zed
+    parent: cot-func-target
+    vars:
+      tox_extra_args: kinetic-zed

--- a/tests/distro-regression/tests/bundles/bionic-queens.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-queens.yaml
@@ -32,7 +32,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
   cinder:
     charm: cs:cinder
     num_units: 1

--- a/tests/distro-regression/tests/bundles/bionic-queens.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-queens.yaml
@@ -5,46 +5,53 @@ variables:
 series: &series bionic
 applications:
   aodh:
-    charm: cs:aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: queens/edge
   ceilometer:
-    charm: cs:ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: queens/edge
   ceilometer-agent:
-    charm: cs:ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: queens/edge
   ceph-mon:
-    charm: cs:ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
       source: *source
     constraints: mem=1024
+    channel: luminous/edge
   ceph-osd:
-    charm: cs:ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       source: *source
     storage:
       osd-devices: cinder,10G
     constraints: mem=4096
+    channel: luminous/edge
   cinder:
-    charm: cs:cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: queens/edge
   cinder-ceph:
-    charm: cs:cinder-ceph
+    charm: ch:cinder-ceph
+    channel: queens/edge
   designate:
-    charm: cs:designate
+    charm: ch:designate
     num_units: 1
     options:
       nameservers: ns1.ubuntu.com.
@@ -54,38 +61,45 @@ applications:
       nova-domain-email: bob@serverstack.ubuntu.com
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: queens/edge
   designate-bind:
-    charm: cs:designate-bind
+    charm: ch:designate-bind
     num_units: 1
+    channel: queens/edge
   glance:
-    charm: cs:glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: queens/edge
   gnocchi:
-    charm: cs:gnocchi
+    charm: ch:gnocchi
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: queens/edge
   heat:
-    charm: cs:heat
+    charm: ch:heat
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: queens/edge
   keystone:
-    charm: cs:keystone
+    charm: ch:keystone
     num_units: 1
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: queens/edge
   memcached:
-    charm: cs:memcached
+    charm: ch:memcached
     num_units: 1
     constraints: mem=1024
+    channel: latest/edge
   mysql:
-    charm: cs:percona-cluster
+    charm: ch:percona-cluster
     num_units: 1
     options:
       dataset-size: 50%
@@ -94,8 +108,9 @@ applications:
       source: *source
       sst-password: ChangeMe123
     constraints: mem=4096
+    channel: latest/edge
   neutron-api:
-    charm: cs:neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       enable-ml2-port-security: true
@@ -105,25 +120,29 @@ applications:
       neutron-security-groups: true
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: queens/edge
   neutron-gateway:
-    charm: cs:neutron-gateway
+    charm: ch:neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
       instance-mtu: 1300
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: queens/edge
   neutron-openvswitch:
-    charm: cs:neutron-openvswitch
+    charm: ch:neutron-openvswitch
+    channel: queens/edge
   nova-cloud-controller:
-    charm: cs:nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
     constraints: mem=2048
+    channel: queens/edge
   nova-compute:
-    charm: cs:nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       enable-live-migration: true
@@ -131,20 +150,23 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: queens/edge
   openstack-dashboard:
-    charm: cs:openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: queens/edge
   rabbitmq-server:
-    charm: cs:rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     options:
       source: *source
     constraints: mem=1024
+    channel: queens/edge
   swift-proxy:
-    charm: cs:swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -152,8 +174,9 @@ applications:
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
       zone-assignment: manual
     constraints: mem=1024
+    channel: queens/edge
   swift-storage-z1:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -161,8 +184,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: queens/edge
   swift-storage-z2:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -170,8 +194,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: queens/edge
   swift-storage-z3:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -179,6 +204,7 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: queens/edge
 relations:
 - - keystone:shared-db
   - mysql:shared-db

--- a/tests/distro-regression/tests/bundles/bionic-rocky.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-rocky.yaml
@@ -38,7 +38,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
   cinder:
     charm: cs:cinder
     num_units: 1

--- a/tests/distro-regression/tests/bundles/bionic-rocky.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-rocky.yaml
@@ -5,52 +5,60 @@ variables:
 series: &series bionic
 applications:
   aodh:
-    charm: cs:aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: rocky/edge
   barbican:
-    charm: cs:barbican
+    charm: ch:barbican
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: rocky/edge
   ceilometer:
-    charm: cs:ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: rocky/edge
   ceilometer-agent:
-    charm: cs:ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: rocky/edge
   ceph-mon:
-    charm: cs:ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
       source: *source
     constraints: mem=1024
+    channel: mimic/edge
   ceph-osd:
-    charm: cs:ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       source: *source
     storage:
       osd-devices: cinder,10G
     constraints: mem=4096
+    channel: mimic/edge
   cinder:
-    charm: cs:cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: rocky/edge
   cinder-ceph:
-    charm: cs:cinder-ceph
+    charm: ch:cinder-ceph
+    channel: rocky/edge
   designate:
-    charm: cs:designate
+    charm: ch:designate
     num_units: 1
     options:
       nameservers: ns1.ubuntu.com.
@@ -60,38 +68,45 @@ applications:
       nova-domain-email: bob@serverstack.ubuntu.com
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: rocky/edge
   designate-bind:
-    charm: cs:designate-bind
+    charm: ch:designate-bind
     num_units: 1
+    channel: rocky/edge
   glance:
-    charm: cs:glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: rocky/edge
   gnocchi:
-    charm: cs:gnocchi
+    charm: ch:gnocchi
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: rocky/edge
   heat:
-    charm: cs:heat
+    charm: ch:heat
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: rocky/edge
   keystone:
-    charm: cs:keystone
+    charm: ch:keystone
     num_units: 1
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: rocky/edge
   memcached:
-    charm: cs:memcached
+    charm: ch:memcached
     num_units: 1
     constraints: mem=1024
+    channel: latest/edge
   mysql:
-    charm: cs:percona-cluster
+    charm: ch:percona-cluster
     num_units: 1
     options:
       dataset-size: 50%
@@ -100,8 +115,9 @@ applications:
       source: *source
       sst-password: ChangeMe123
     constraints: mem=4096
+    channel: latest/edge
   neutron-api:
-    charm: cs:neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       enable-ml2-port-security: true
@@ -111,25 +127,29 @@ applications:
       neutron-security-groups: true
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: rocky/edge
   neutron-gateway:
-    charm: cs:neutron-gateway
+    charm: ch:neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
       instance-mtu: 1300
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: rocky/edge
   neutron-openvswitch:
-    charm: cs:neutron-openvswitch
+    charm: ch:neutron-openvswitch
+    channel: rocky/edge
   nova-cloud-controller:
-    charm: cs:nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
     constraints: mem=2048
+    channel: rocky/edge
   nova-compute:
-    charm: cs:nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       enable-live-migration: true
@@ -137,20 +157,23 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: rocky/edge
   openstack-dashboard:
-    charm: cs:openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: rocky/edge
   rabbitmq-server:
-    charm: cs:rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     options:
       source: *source
     constraints: mem=1024
+    channel: 3.8/edge
   swift-proxy:
-    charm: cs:swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -158,8 +181,9 @@ applications:
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
       zone-assignment: manual
     constraints: mem=1024
+    channel: rocky/edge
   swift-storage-z1:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -167,8 +191,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: rocky/edge
   swift-storage-z2:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -176,8 +201,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: rocky/edge
   swift-storage-z3:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -185,33 +211,37 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: rocky/edge
   neutron-openvswitch-octavia:
-    series: bionic
-    charm: cs:neutron-openvswitch
+    charm: ch:neutron-openvswitch
     num_units: 0
     options:
       debug: True
       prevent-arp-spoofing: False
       firewall-driver: openvswitch
+    channel: rocky/edge
   octavia:
-    charm: cs:octavia
+    charm: ch:octavia
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    channel: rocky/edge
   glance-simplestreams-sync:
-    charm: cs:glance-simplestreams-sync
+    charm: ch:glance-simplestreams-sync
     num_units: 1
     options:
       use_swift: true
     constraints: root-disk=8G
+    channel: rocky/edge
   octavia-diskimage-retrofit:
-    charm: cs:octavia-diskimage-retrofit
+    charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-uca-pocket: rocky
       retrofit-series: bionic
+    channel: rocky/edge
 relations:
 - - keystone:shared-db
   - mysql:shared-db

--- a/tests/distro-regression/tests/bundles/bionic-rocky.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-rocky.yaml
@@ -1,6 +1,7 @@
 variables:
   source: &source cloud:bionic-rocky/proposed
   openstack-origin: &openstack-origin cloud:bionic-rocky/proposed
+  retrofit-uca-pocket: &retrofit-uca-pocket rocky
 
 series: &series bionic
 applications:
@@ -239,8 +240,8 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
+      retrofit-uca-pocket: *retrofit-uca-pocket
     channel: rocky/edge
 relations:
 - - keystone:shared-db

--- a/tests/distro-regression/tests/bundles/bionic-stein.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-stein.yaml
@@ -38,7 +38,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
   cinder:
     charm: cs:cinder
     num_units: 1

--- a/tests/distro-regression/tests/bundles/bionic-stein.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-stein.yaml
@@ -1,6 +1,7 @@
 variables:
   source: &source cloud:bionic-stein/proposed
   openstack-origin: &openstack-origin cloud:bionic-stein/proposed
+  retrofit-uca-pocket: &retrofit-uca-pocket stein
 
 series: &series bionic
 applications:
@@ -239,8 +240,8 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
+      retrofit-uca-pocket: *retrofit-uca-pocket
     channel: stein/edge
 relations:
 - - keystone:shared-db

--- a/tests/distro-regression/tests/bundles/bionic-stein.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-stein.yaml
@@ -5,52 +5,60 @@ variables:
 series: &series bionic
 applications:
   aodh:
-    charm: cs:aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: stein/edge
   barbican:
-    charm: cs:barbican
+    charm: ch:barbican
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: stein/edge
   ceilometer:
-    charm: cs:ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: stein/edge
   ceilometer-agent:
-    charm: cs:ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: stein/edge
   ceph-mon:
-    charm: cs:ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
       source: *source
     constraints: mem=1024
+    channel: octopus/edge
   ceph-osd:
-    charm: cs:ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       source: *source
     storage:
       osd-devices: cinder,10G
     constraints: mem=4096
+    channel: octopus/edge
   cinder:
-    charm: cs:cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: stein/edge
   cinder-ceph:
-    charm: cs:cinder-ceph
+    charm: ch:cinder-ceph
+    channel: stein/edge
   designate:
-    charm: cs:designate
+    charm: ch:designate
     num_units: 1
     options:
       nameservers: ns1.ubuntu.com.
@@ -60,38 +68,45 @@ applications:
       nova-domain-email: bob@serverstack.ubuntu.com
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: stein/edge
   designate-bind:
-    charm: cs:designate-bind
+    charm: ch:designate-bind
     num_units: 1
+    channel: stein/edge
   glance:
-    charm: cs:glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: stein/edge
   gnocchi:
-    charm: cs:gnocchi
+    charm: ch:gnocchi
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: stein/edge
   heat:
-    charm: cs:heat
+    charm: ch:heat
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: stein/edge
   keystone:
-    charm: cs:keystone
+    charm: ch:keystone
     num_units: 1
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: stein/edge
   memcached:
-    charm: cs:memcached
+    charm: ch:memcached
     num_units: 1
     constraints: mem=1024
+    channel: latest/edge
   mysql:
-    charm: cs:percona-cluster
+    charm: ch:percona-cluster
     num_units: 1
     options:
       dataset-size: 50%
@@ -100,8 +115,9 @@ applications:
       source: *source
       sst-password: ChangeMe123
     constraints: mem=4096
+    channel: latest/edge
   neutron-api:
-    charm: cs:neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       enable-ml2-port-security: true
@@ -111,25 +127,29 @@ applications:
       neutron-security-groups: true
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: stein/edge
   neutron-gateway:
-    charm: cs:neutron-gateway
+    charm: ch:neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
       instance-mtu: 1300
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: stein/edge
   neutron-openvswitch:
-    charm: cs:neutron-openvswitch
+    charm: ch:neutron-openvswitch
+    channel: stein/edge
   nova-cloud-controller:
-    charm: cs:nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
     constraints: mem=2048
+    channel: stein/edge
   nova-compute:
-    charm: cs:nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       enable-live-migration: true
@@ -137,20 +157,23 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: stein/edge
   openstack-dashboard:
-    charm: cs:openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: stein/edge
   rabbitmq-server:
-    charm: cs:rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     options:
       source: *source
     constraints: mem=1024
+    channel: 3.8/edge
   swift-proxy:
-    charm: cs:swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -158,8 +181,9 @@ applications:
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
       zone-assignment: manual
     constraints: mem=1024
+    channel: stein/edge
   swift-storage-z1:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -167,8 +191,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: stein/edge
   swift-storage-z2:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -176,8 +201,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: stein/edge
   swift-storage-z3:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -185,33 +211,37 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: stein/edge
   neutron-openvswitch-octavia:
-    series: bionic
-    charm: cs:neutron-openvswitch
+    charm: ch:neutron-openvswitch
     num_units: 0
     options:
       debug: True
       prevent-arp-spoofing: False
       firewall-driver: openvswitch
+    channel: stein/edge
   octavia:
-    charm: cs:octavia
+    charm: ch:octavia
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    channel: stein/edge
   glance-simplestreams-sync:
-    charm: cs:glance-simplestreams-sync
+    charm: ch:glance-simplestreams-sync
     num_units: 1
     options:
       use_swift: true
     constraints: root-disk=8G
+    channel: stein/edge
   octavia-diskimage-retrofit:
-    charm: cs:octavia-diskimage-retrofit
+    charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-uca-pocket: rocky
       retrofit-series: bionic
+    channel: stein/edge
 relations:
 - - keystone:shared-db
   - mysql:shared-db

--- a/tests/distro-regression/tests/bundles/bionic-train.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-train.yaml
@@ -38,7 +38,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
   cinder:
     charm: cs:cinder
     num_units: 1

--- a/tests/distro-regression/tests/bundles/bionic-train.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-train.yaml
@@ -5,52 +5,60 @@ variables:
 series: &series bionic
 applications:
   aodh:
-    charm: cs:aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: train/edge
   barbican:
-    charm: cs:barbican
+    charm: ch:barbican
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: train/edge
   ceilometer:
-    charm: cs:ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: train/edge
   ceilometer-agent:
-    charm: cs:ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: train/edge
   ceph-mon:
-    charm: cs:ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
       source: *source
     constraints: mem=1024
+    channel: nautilus/edge
   ceph-osd:
-    charm: cs:ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       source: *source
     storage:
       osd-devices: cinder,10G
     constraints: mem=4096
+    channel: nautilus/edge
   cinder:
-    charm: cs:cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: train/edge
   cinder-ceph:
-    charm: cs:cinder-ceph
+    charm: ch:cinder-ceph
+    channel: train/edge
   designate:
-    charm: cs:designate
+    charm: ch:designate
     num_units: 1
     options:
       nameservers: ns1.ubuntu.com.
@@ -60,38 +68,45 @@ applications:
       nova-domain-email: bob@serverstack.ubuntu.com
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: train/edge
   designate-bind:
-    charm: cs:designate-bind
+    charm: ch:designate-bind
     num_units: 1
+    channel: train/edge
   glance:
-    charm: cs:glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: train/edge
   gnocchi:
-    charm: cs:gnocchi
+    charm: ch:gnocchi
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: train/edge
   heat:
-    charm: cs:heat
+    charm: ch:heat
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: train/edge
   keystone:
-    charm: cs:keystone
+    charm: ch:keystone
     num_units: 1
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: train/edge
   memcached:
-    charm: cs:memcached
+    charm: ch:memcached
     num_units: 1
     constraints: mem=1024
+    channel: latest/edge
   mysql:
-    charm: cs:percona-cluster
+    charm: ch:percona-cluster
     num_units: 1
     options:
       dataset-size: 50%
@@ -100,8 +115,9 @@ applications:
       source: *source
       sst-password: ChangeMe123
     constraints: mem=4096
+    channel: latest/edge
   neutron-api:
-    charm: cs:neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       enable-ml2-port-security: true
@@ -111,25 +127,29 @@ applications:
       neutron-security-groups: true
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: train/edge
   neutron-gateway:
-    charm: cs:neutron-gateway
+    charm: ch:neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
       instance-mtu: 1300
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: train/edge
   neutron-openvswitch:
-    charm: cs:neutron-openvswitch
+    charm: ch:neutron-openvswitch
+    channel: train/edge
   nova-cloud-controller:
-    charm: cs:nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
     constraints: mem=2048
+    channel: train/edge
   nova-compute:
-    charm: cs:nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       enable-live-migration: true
@@ -137,26 +157,30 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: train/edge
   openstack-dashboard:
-    charm: cs:openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: train/edge
   placement:
-    charm: cs:placement
+    charm: ch:placement
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: train/edge
   rabbitmq-server:
-    charm: cs:rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     options:
       source: *source
     constraints: mem=1024
+    channel: 3.8/edge
   swift-proxy:
-    charm: cs:swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -164,8 +188,9 @@ applications:
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
       zone-assignment: manual
     constraints: mem=1024
+    channel: train/edge
   swift-storage-z1:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -173,8 +198,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: train/edge
   swift-storage-z2:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -182,8 +208,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: train/edge
   swift-storage-z3:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -191,33 +218,37 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: train/edge
   neutron-openvswitch-octavia:
-    series: bionic
-    charm: cs:neutron-openvswitch
+    charm: ch:neutron-openvswitch
     num_units: 0
     options:
       debug: True
       prevent-arp-spoofing: False
       firewall-driver: openvswitch
+    channel: train/edge
   octavia:
-    charm: cs:octavia
+    charm: ch:octavia
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    channel: train/edge
   glance-simplestreams-sync:
-    charm: cs:glance-simplestreams-sync
+    charm: ch:glance-simplestreams-sync
     num_units: 1
     options:
       use_swift: true
     constraints: root-disk=8G
+    channel: train/edge
   octavia-diskimage-retrofit:
-    charm: cs:octavia-diskimage-retrofit
+    charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-uca-pocket: rocky
       retrofit-series: bionic
+    channel: train/edge
 relations:
 - - keystone:shared-db
   - mysql:shared-db

--- a/tests/distro-regression/tests/bundles/bionic-train.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-train.yaml
@@ -1,6 +1,7 @@
 variables:
   source: &source cloud:bionic-train/proposed
   openstack-origin: &openstack-origin cloud:bionic-train/proposed
+  retrofit-uca-pocket: &retrofit-uca-pocket train
 
 series: &series bionic
 applications:
@@ -246,8 +247,8 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
+      retrofit-uca-pocket: *retrofit-uca-pocket
     channel: train/edge
 relations:
 - - keystone:shared-db

--- a/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
@@ -38,7 +38,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
   cinder:
     charm: cs:cinder
     num_units: 1

--- a/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
@@ -1,6 +1,7 @@
 variables:
   source: &source cloud:bionic-ussuri/proposed
   openstack-origin: &openstack-origin cloud:bionic-ussuri/proposed
+  retrofit-uca-pocket: &retrofit-uca-pocket ussuri
 
 series: &series bionic
 applications:
@@ -248,8 +249,8 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
+      retrofit-uca-pocket: *retrofit-uca-pocket
     channel: ussuri/edge
 relations:
 - - keystone:shared-db

--- a/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
@@ -5,52 +5,60 @@ variables:
 series: &series bionic
 applications:
   aodh:
-    charm: cs:aodh
+    charm: ch:aodh
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   barbican:
-    charm: cs:barbican
+    charm: ch:barbican
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   ceilometer:
-    charm: cs:ceilometer
+    charm: ch:ceilometer
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   ceilometer-agent:
-    charm: cs:ceilometer-agent
+    charm: ch:ceilometer-agent
+    channel: ussuri/edge
   ceph-mon:
-    charm: cs:ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
       source: *source
     constraints: mem=1024
+    channel: octopus/edge
   ceph-osd:
-    charm: cs:ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       source: *source
     storage:
       osd-devices: cinder,10G
     constraints: mem=4096
+    channel: octopus/edge
   cinder:
-    charm: cs:cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
       glance-api-version: 2
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   cinder-ceph:
-    charm: cs:cinder-ceph
+    charm: ch:cinder-ceph
+    channel: ussuri/edge
   designate:
-    charm: cs:designate
+    charm: ch:designate
     num_units: 1
     options:
       nameservers: ns1.ubuntu.com.
@@ -60,38 +68,45 @@ applications:
       nova-domain-email: bob@serverstack.ubuntu.com
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   designate-bind:
-    charm: cs:designate-bind
+    charm: ch:designate-bind
     num_units: 1
+    channel: ussuri/edge
   glance:
-    charm: cs:glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   gnocchi:
-    charm: cs:gnocchi
+    charm: ch:gnocchi
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: ussuri/edge
   heat:
-    charm: cs:heat
+    charm: ch:heat
     num_units: 1
     options:
       openstack-origin: *openstack-origin
+    channel: ussuri/edge
   keystone:
-    charm: cs:keystone
+    charm: ch:keystone
     num_units: 1
     options:
       admin-password: openstack
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   memcached:
-    charm: cs:memcached
+    charm: ch:memcached
     num_units: 1
     constraints: mem=1024
+    channel: latest/edge
   mysql:
-    charm: cs:percona-cluster
+    charm: ch:percona-cluster
     num_units: 1
     options:
       dataset-size: 50%
@@ -100,8 +115,9 @@ applications:
       source: *source
       sst-password: ChangeMe123
     constraints: mem=4096
+    channel: latest/edge
   neutron-api:
-    charm: cs:neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       manage-neutron-plugin-legacy-mode: True
@@ -113,25 +129,29 @@ applications:
       neutron-security-groups: true
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   neutron-gateway:
-    charm: cs:neutron-gateway
+    charm: ch:neutron-gateway
     num_units: 1
     options:
       bridge-mappings: physnet1:br-ex
       instance-mtu: 1300
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: ussuri/edge
   neutron-openvswitch:
-    charm: cs:neutron-openvswitch
+    charm: ch:neutron-openvswitch
+    channel: ussuri/edge
   nova-cloud-controller:
-    charm: cs:nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
     constraints: mem=2048
+    channel: ussuri/edge
   nova-compute:
-    charm: cs:nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       enable-live-migration: true
@@ -139,26 +159,30 @@ applications:
       migration-auth-type: ssh
       openstack-origin: *openstack-origin
     constraints: mem=4096
+    channel: ussuri/edge
   openstack-dashboard:
-    charm: cs:openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   placement:
-    charm: cs:placement
+    charm: ch:placement
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     constraints: mem=1024
+    channel: ussuri/edge
   rabbitmq-server:
-    charm: cs:rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     options:
       source: *source
     constraints: mem=1024
+    channel: 3.8/edge
   swift-proxy:
-    charm: cs:swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -166,8 +190,9 @@ applications:
       swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
       zone-assignment: manual
     constraints: mem=1024
+    channel: ussuri/edge
   swift-storage-z1:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -175,8 +200,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: ussuri/edge
   swift-storage-z2:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -184,8 +210,9 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: ussuri/edge
   swift-storage-z3:
-    charm: cs:swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -193,33 +220,37 @@ applications:
     storage:
       block-devices: cinder,10G
     constraints: mem=1024
+    channel: ussuri/edge
   neutron-openvswitch-octavia:
-    series: bionic
-    charm: cs:neutron-openvswitch
+    charm: ch:neutron-openvswitch
     num_units: 0
     options:
       debug: True
       prevent-arp-spoofing: False
       firewall-driver: openvswitch
+    channel: ussuri/edge
   octavia:
-    charm: cs:octavia
+    charm: ch:octavia
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    channel: ussuri/edge
   glance-simplestreams-sync:
-    charm: cs:glance-simplestreams-sync
+    charm: ch:glance-simplestreams-sync
     num_units: 1
     options:
       use_swift: true
     constraints: root-disk=8G
+    channel: ussuri/edge
   octavia-diskimage-retrofit:
-    charm: cs:octavia-diskimage-retrofit
+    charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-uca-pocket: rocky
       retrofit-series: bionic
+    channel: ussuri/edge
 relations:
 - - keystone:shared-db
   - mysql:shared-db

--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -49,7 +49,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: octopus/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -275,8 +275,7 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
     channel: ussuri/edge
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -49,7 +49,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: octopus/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -1,6 +1,7 @@
 variables:
   source: &source cloud:focal-victoria/proposed
   openstack-origin: &openstack-origin cloud:focal-victoria/proposed
+  retrofit-uca-pocket: &retrofit-uca-pocket victoria
 
 series: &series focal
 applications:
@@ -275,8 +276,8 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
+      retrofit-uca-pocket: *retrofit-uca-pocket
     channel: victoria/edge
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/focal-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: pacific/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/focal-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby.yaml
@@ -38,7 +38,7 @@ applications:
     num_units: 1
     charm: ch:ceph-fs
     options:
-      source: *openstack-origin
+      source: *source
     channel: pacific/edge
   ceph-mon:
     charm: ch:ceph-mon

--- a/tests/distro-regression/tests/bundles/focal-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby.yaml
@@ -1,6 +1,7 @@
 variables:
   source: &source cloud:focal-wallaby/proposed
   openstack-origin: &openstack-origin cloud:focal-wallaby/proposed
+  retrofit-uca-pocket: &retrofit-uca-pocket wallaby
 
 series: &series focal
 applications:
@@ -301,8 +302,8 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
+      retrofit-uca-pocket: *retrofit-uca-pocket
     channel: wallaby/edge
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/focal-xena.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena.yaml
@@ -1,6 +1,7 @@
 variables:
   source: &source cloud:focal-xena/proposed
   openstack-origin: &openstack-origin cloud:focal-xena/proposed
+  retrofit-uca-pocket: &retrofit-uca-pocket xena
 
 series: &series focal
 applications:
@@ -301,8 +302,8 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
+      retrofit-uca-pocket: *retrofit-uca-pocket
     channel: xena/edge
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/focal-xena.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: pacific/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/focal-xena.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena.yaml
@@ -38,7 +38,7 @@ applications:
     num_units: 1
     charm: ch:ceph-fs
     options:
-      source: *openstack-origin
+      source: *source
     channel: pacific/edge
   ceph-mon:
     charm: ch:ceph-mon

--- a/tests/distro-regression/tests/bundles/focal-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/focal-yoga.yaml
@@ -38,7 +38,7 @@ applications:
     num_units: 1
     charm: ch:ceph-fs
     options:
-      source: *openstack-origin
+      source: *source
     channel: quincy/edge
   ceph-mon:
     charm: ch:ceph-mon

--- a/tests/distro-regression/tests/bundles/focal-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/focal-yoga.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: quincy/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/focal-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/focal-yoga.yaml
@@ -1,6 +1,7 @@
 variables:
   source: &source cloud:focal-yoga/proposed
   openstack-origin: &openstack-origin cloud:focal-yoga/proposed
+  retrofit-uca-pocket: &retrofit-uca-pocket yoga
 
 series: &series focal
 applications:
@@ -301,8 +302,8 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
+      retrofit-uca-pocket: *retrofit-uca-pocket
     channel: yoga/edge
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/jammy-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga.yaml
@@ -38,7 +38,7 @@ applications:
     num_units: 1
     charm: ch:ceph-fs
     options:
-      source: *openstack-origin
+      source: *source
     channel: quincy/edge
   ceph-mon:
     charm: ch:ceph-mon

--- a/tests/distro-regression/tests/bundles/jammy-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga.yaml
@@ -301,8 +301,7 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
     channel: yoga/edge
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/jammy-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: quincy/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/jammy-zed.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed.yaml
@@ -1,6 +1,7 @@
 variables:
   source: &source cloud:jammy-zed/proposed
   openstack-origin: &openstack-origin cloud:jammy-zed/proposed
+  retrofit-uca-pocket: &retrofit-uca-pocket zed
 
 series: &series jammy
 applications:
@@ -301,8 +302,8 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
+      retrofit-uca-pocket: *retrofit-uca-pocket
     channel: latest/edge
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/jammy-zed.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed.yaml
@@ -38,7 +38,7 @@ applications:
     num_units: 1
     charm: ch:ceph-fs
     options:
-      source: *openstack-origin
+      source: *source
     channel: latest/edge
   ceph-mon:
     charm: ch:ceph-mon

--- a/tests/distro-regression/tests/bundles/jammy-zed.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: latest/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/kinetic-zed.yaml
+++ b/tests/distro-regression/tests/bundles/kinetic-zed.yaml
@@ -295,6 +295,10 @@ applications:
     num_units: 1
     options:
       use_swift: true
+      mirror_list: "[{url: 'http://cloud-images.ubuntu.com/releases/',
+                      name_prefix: 'ubuntu:released',
+                      path: 'streams/v1/index.sjson', max: 1,
+                      item_filters: ['release~(jammy|kinetic)', 'arch~(x86_64|amd64)', 'ftype~(disk1.img|disk.img)']}]"
     constraints: root-disk=8G
     channel: latest/edge
   octavia-diskimage-retrofit:

--- a/tests/distro-regression/tests/bundles/kinetic-zed.yaml
+++ b/tests/distro-regression/tests/bundles/kinetic-zed.yaml
@@ -38,7 +38,7 @@ applications:
     num_units: 1
     charm: ch:ceph-fs
     options:
-      source: *openstack-origin
+      source: *source
     channel: latest/edge
   ceph-mon:
     charm: ch:ceph-mon

--- a/tests/distro-regression/tests/bundles/kinetic-zed.yaml
+++ b/tests/distro-regression/tests/bundles/kinetic-zed.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: latest/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/kinetic-zed.yaml
+++ b/tests/distro-regression/tests/bundles/kinetic-zed.yaml
@@ -305,8 +305,7 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-uca-pocket: rocky
-      retrofit-series: bionic
+      retrofit-series: *series
     channel: latest/edge
 relations:
 - - nova-cloud-controller:amqp


### PR DESCRIPTION
These patches include changes to the distro bundles for:
  * Align osci.yaml with supported distro bundles
  * The retrofit-series and retrofit-uca-pocket are set to the series and
     UCA pocket that each bundle is deploying.
  * Update gss config in the kinetic bundle to sync the kinetic image since
     that is what the octavia-diskimage-retrofit retrofit-image action will be
     tested with.
  * Fix distro typos in distro bundles
  * Switch remaining distro bundles to charmhub
  * Bump ceph-osd memory constraint to mem=4096 for all of the distro
     bundles as we have recently started hitting issues with ceph-osds not
     being functional with mem=1024.