### PR TITLE
Bump ceph-osd memory constraint to mem=4096

### DIFF
--- a/tests/distro-regression/tests/bundles/bionic-queens.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-queens.yaml
@@ -36,7 +36,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: luminous/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/bionic-rocky.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-rocky.yaml
@@ -43,7 +43,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: mimic/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/bionic-stein.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-stein.yaml
@@ -43,7 +43,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: octopus/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/bionic-train.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-train.yaml
@@ -43,7 +43,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: nautilus/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
@@ -43,7 +43,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: octopus/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -49,7 +49,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: octopus/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -49,7 +49,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: octopus/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/focal-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: pacific/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/focal-xena.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: pacific/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/focal-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/focal-yoga.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: quincy/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/jammy-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: quincy/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/jammy-zed.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed.yaml
@@ -55,7 +55,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: latest/edge
   cinder:
     charm: ch:cinder

--- a/tests/distro-regression/tests/bundles/kinetic-zed.yaml
+++ b/tests/distro-regression/tests/bundles/kinetic-zed.yaml
@@ -60,7 +60,7 @@ applications:
       source: *source
     storage:
       osd-devices: cinder,10G
-    constraints: mem=1024
+    constraints: mem=4096
     channel: edge
   cinder:
     charm: ch:cinder


### PR DESCRIPTION
The ceph-osd memory constraint is bumped to mem=4096 for all of the distro bundles as we have recently
started hitting issues with ceph-osds not being
functional with mem=1024.