### PR TITLE
Update gss config with kinetic image

### DIFF
--- a/tests/distro-regression/tests/bundles/kinetic-zed.yaml
+++ b/tests/distro-regression/tests/bundles/kinetic-zed.yaml
@@ -295,6 +295,10 @@ applications:
     num_units: 1
     options:
       use_swift: true
+      mirror_list: "[{url: 'http://cloud-images.ubuntu.com/releases/',
+                      name_prefix: 'ubuntu:released',
+                      path: 'streams/v1/index.sjson', max: 1,
+                      item_filters: ['release~(jammy|kinetic)', 'arch~(x86_64|amd64)', 'ftype~(disk1.img|disk.img)']}]"
     constraints: root-disk=8G
     channel: latest/edge
   octavia-diskimage-retrofit:


### PR DESCRIPTION
The default mirror_list for gss adds LTS images. This adds a kinetic image to the kinetic bundle since that is what the octavia-diskimage-retrofit retrofit-image action will be tested with.