### PR TITLE
Remove SQA Integration Jobs

### DIFF
--- a/osci.yaml
+++ b/osci.yaml
@@ -20,8 +20,6 @@
       - cot_distro-regression_hirsute-wallaby
       - cot_distro-regression_focal-xena
       - cot_distro-regression_impish-xena
-      - cot_sqa-integration_jammy-yoga
-      - cot_sqa-integration_focal-yoga
 - job:
     name: cot-func-target
     parent: func-target
@@ -100,16 +98,11 @@
     vars:
       sqalab:
         lab: lab1
-        repo: git+ssh://oil-ci-bot@git.launchpad.net/solutions-qa-deployments
 - job:
     name: cot_sqa-integration_jammy-yoga
     parent: cot-sqa-integration
     vars:
       sqalab:
-        # the branch refers to a branch in {{ sqalab.repo }} which defines what the deployment looks like. 
-        # The default repo is maintained by SQA and should have up-to-date deployments. If you can't find
-        # a suitable branch in the repo, you can either contact the SQA team to create one or create
-        # a branch in your own repo (make sure to include `git+ssh://oil-ci-bot@` in the repo variable)
         branch: solutionsqa/fcb/sku/master-yoga-jammy
 - job:
     name: cot_sqa-integration_focal-yoga

--- a/osci.yaml
+++ b/osci.yaml
@@ -1,9 +1,6 @@
 - semaphore:
     name: distro-regression
     max: 2
-- semaphore:
-    name: sqa-integration
-    max: 1
 - project:
     periodic-weekly:
       jobs:
@@ -90,23 +87,3 @@
     parent: cot-func-target
     vars:
       tox_extra_args: impish-xena
-- job:
-    name: cot-sqa-integration
-    parent: sqa-integration
-    semaphore: sqa-integration
-    abstract: true
-    vars:
-      sqalab:
-        lab: lab1
-- job:
-    name: cot_sqa-integration_jammy-yoga
-    parent: cot-sqa-integration
-    vars:
-      sqalab:
-        branch: solutionsqa/fcb/sku/master-yoga-jammy
-- job:
-    name: cot_sqa-integration_focal-yoga
-    parent: cot-sqa-integration
-    vars:
-      sqalab:
-        branch: solutionsqa/fcb/sku/master-yoga-focal


### PR DESCRIPTION
The SQA-integrations jobs are moved to a separate repo (https://github.com/openstack-charmers/sqa-integration-tester) and are no longer needed here.