### PR TITLE
iptables updates to allow LXD traffic in workflow

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -20,6 +20,9 @@ jobs:
         sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
         # until Juju provides stable IPv6-support we unfortunately need this
         lxc network set lxdbr0 ipv6.address none
+        # iptables updates to allow traffic to/from LXD bridge/external network
+        sudo iptables -I DOCKER-USER -i lxdbr0 -o eth0 -j ACCEPT
+        sudo iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
         juju bootstrap --no-gui localhost
     - name: Bundle validation with tox using dry-run juju deploy
       run: tox -e lint


### PR DESCRIPTION
The moby-cli package is installed on the runners,
which is installing /usr/bin/docker. I assume this package or one of its dependencies is also updating iptables which is preventing traffic between the LXD bridge and external network.