### PR TITLE
Add debug step to workflow and deal with new tox

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -26,3 +26,6 @@ jobs:
         juju bootstrap --no-gui localhost
     - name: Bundle validation with tox using dry-run juju deploy
       run: tox -e lint
+    - name: consider debugging
+      uses: lhotari/action-upterm@v1
+      if: failure()

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,14 @@
 [tox]
 envlist = pep8
 skipsdist = True
-
-# NOTES:
-# * We avoid the new dependency resolver by pinning pip < 20.3, see
-#   https://github.com/pypa/pip/issues/9187
-# * Pinning dependencies requires tox >= 3.2.0, see
-#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
-# * It is also necessary to pin virtualenv as a newer virtualenv would still
-#   lead to fetching the latest pip in the func* tox targets, see
-#   https://stackoverflow.com/a/38133283
-requires = pip < 20.3
-           virtualenv < 20.0
-# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
-whitelist_externals = juju
+allowlist_externals =
+  juju
+  bash
 passenv = HOME TERM CS_* OS_* TEST_*
 deps = -r{toxinidir}/test-requirements.txt
 install_command =


### PR DESCRIPTION
This allows for debbuging via ssh if our workflow fails.
https://github.com/lhotari/action-upterm

tox 4.x is also out and causing some issues so we deal
with that here.