### PR TITLE
Move tox passenv variables to separate lines

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,12 @@ setenv = VIRTUAL_ENV={envdir}
 allowlist_externals =
   juju
   bash
-passenv = HOME TERM CS_* OS_* TEST_*
+passenv =
+  HOME
+  TERM
+  CS_*
+  OS_*
+  TEST_*
 deps = -r{toxinidir}/test-requirements.txt
 install_command =
   pip install {opts} {packages}


### PR DESCRIPTION
tox no longer support space-separation for a single line with multiple variables. They need to either be space-separated or on separate lines.