### PR TITLE
Bundle updates to work-around disimage-retrofit bug

### DIFF
--- a/tests/distro-regression/tests/bundles/jammy-antelope.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-antelope.yaml
@@ -1,7 +1,11 @@
 variables:
   source: &source cloud:jammy-antelope/proposed
   openstack-origin: &openstack-origin cloud:jammy-antelope/proposed
-  retrofit-uca-pocket: &retrofit-uca-pocket antelope
+  # retrofit-series: &retrofit-series jammy
+  # retrofit-uca-pocket: &retrofit-uca-pocket antelope
+  # Set retrofit-series to focal to work-around the following bug:
+  # https://bugs.launchpad.net/snap-octavia-diskimage-retrofit/+bug/1995130
+  retrofit-series: &retrofit-series focal
 
 series: &series jammy
 applications:
@@ -300,8 +304,10 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-series: *series
-      retrofit-uca-pocket: *retrofit-uca-pocket
+      retrofit-series: *retrofit-series
+      # Disable retrofit-uca-pocket until the following bug is fixed:
+      # https://bugs.launchpad.net/snap-octavia-diskimage-retrofit/+bug/1995130
+      # retrofit-uca-pocket: *retrofit-uca-pocket
     channel: latest/edge
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/jammy-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga.yaml
@@ -1,6 +1,10 @@
 variables:
   source: &source proposed
   openstack-origin: &openstack-origin distro-proposed
+  # retrofit-series: &retrofit-series jammy
+  # Set retrofit-series to focal to work-around the following bug:
+  # https://bugs.launchpad.net/snap-octavia-diskimage-retrofit/+bug/1995130
+  retrofit-series: &retrofit-series focal
 
 series: &series jammy
 applications:
@@ -301,7 +305,7 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-series: *series
+      retrofit-series: *retrofit-series
     channel: yoga/edge
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/jammy-zed.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed.yaml
@@ -1,7 +1,11 @@
 variables:
   source: &source cloud:jammy-zed/proposed
   openstack-origin: &openstack-origin cloud:jammy-zed/proposed
-  retrofit-uca-pocket: &retrofit-uca-pocket zed
+  # retrofit-series: &retrofit-series jammy
+  # retrofit-uca-pocket: &retrofit-uca-pocket zed
+  # Set retrofit-series to focal to work-around the following bug:
+  # https://bugs.launchpad.net/snap-octavia-diskimage-retrofit/+bug/1995130
+  retrofit-series: &retrofit-series focal
 
 series: &series jammy
 applications:
@@ -300,8 +304,10 @@ applications:
     charm: ch:octavia-diskimage-retrofit
     options:
       amp-image-tag: 'octavia-amphora'
-      retrofit-series: *series
-      retrofit-uca-pocket: *retrofit-uca-pocket
+      retrofit-series: *retrofit-series
+      # Disable retrofit-uca-pocket until the following bug is fixed:
+      # https://bugs.launchpad.net/snap-octavia-diskimage-retrofit/+bug/1995130
+      # retrofit-uca-pocket: *retrofit-uca-pocket
     channel: latest/edge
 relations:
 - - nova-cloud-controller:amqp


### PR DESCRIPTION
Update jammy+ bundles to work around the following bug: https://bugs.launchpad.net/snap-octavia-diskimage-retrofit/+bug/1995130