### PR TITLE
Add OpenStack Magnum support

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,3 +14,4 @@ cinder-tempest-plugin;python_version<'3.6'
 designate-tempest-plugin;python_version<'3.6'
 setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 octavia-tempest-plugin
+magnum-tempest-plugin

--- a/tests/distro-regression/tests/bundles/focal-ussuri-base.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri-base.yaml
@@ -1,0 +1,315 @@
+variables:
+  source: &source proposed
+  openstack-origin: &openstack-origin distro-proposed
+  openstack-channel: &openstack-channel ussuri/edge
+  ceph-channel: &ceph-channel octopus/edge
+  ovn-channel: &ovn-channel 20.03/edge
+
+series: &series focal
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+    channel: *ceph-channel
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=4096
+    channel: *ceph-channel
+  cinder:
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  cinder-ceph:
+    charm: ch:cinder-ceph
+    channel: *openstack-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  glance:
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  keystone:
+    charm: ch:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/edge
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+    channel: 8.0/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: 1.7/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    channel: *ovn-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+  neutron-api:
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+    channel: *openstack-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  nova-cloud-controller:
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+    channel: *openstack-channel
+  nova-compute:
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+    channel: *openstack-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement:
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  rabbitmq-server:
+    charm: ch:rabbitmq-server
+    num_units: 1
+    constraints: mem=1024
+    channel: 3.8/edge
+  glance-simplestreams-sync:
+    charm: ch:glance-simplestreams-sync
+    num_units: 1
+    options:
+      use_swift: true
+    constraints: root-disk=8G
+    channel: *openstack-channel
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - vault:certificates
+  - glance-simplestreams-sync:certificates
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates

--- a/tests/distro-regression/tests/bundles/focal-ussuri-magnum.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri-magnum.yaml
@@ -1,0 +1,1 @@
+focal-ussuri-base.yaml

--- a/tests/distro-regression/tests/bundles/focal-victoria-base.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria-base.yaml
@@ -1,0 +1,315 @@
+variables:
+  source: &source cloud:focal-victoria/proposed
+  openstack-origin: &openstack-origin cloud:focal-victoria/proposed
+  openstack-channel: &openstack-channel victoria/edge
+  ceph-channel: &ceph-channel octopus/edge
+  ovn-channel: &ovn-channel 20.03/edge
+
+series: &series focal
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+    channel: *ceph-channel
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=4096
+    channel: *ceph-channel
+  cinder:
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  cinder-ceph:
+    charm: ch:cinder-ceph
+    channel: *openstack-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  glance:
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  keystone:
+    charm: ch:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/edge
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+    channel: 8.0/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: 1.7/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    channel: *ovn-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+  neutron-api:
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+    channel: *openstack-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  nova-cloud-controller:
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+    channel: *openstack-channel
+  nova-compute:
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+    channel: *openstack-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement:
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  rabbitmq-server:
+    charm: ch:rabbitmq-server
+    num_units: 1
+    constraints: mem=1024
+    channel: 3.8/edge
+  glance-simplestreams-sync:
+    charm: ch:glance-simplestreams-sync
+    num_units: 1
+    options:
+      use_swift: true
+    constraints: root-disk=8G
+    channel: *openstack-channel
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - vault:certificates
+  - glance-simplestreams-sync:certificates
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates

--- a/tests/distro-regression/tests/bundles/focal-victoria-magnum.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria-magnum.yaml
@@ -1,0 +1,1 @@
+focal-victoria-base.yaml

--- a/tests/distro-regression/tests/bundles/focal-wallaby-base.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby-base.yaml
@@ -1,0 +1,315 @@
+variables:
+  source: &source cloud:focal-wallaby/proposed
+  openstack-origin: &openstack-origin cloud:focal-wallaby/proposed
+  openstack-channel: &openstack-channel wallaby/edge
+  ceph-channel: &ceph-channel pacific/edge
+  ovn-channel: &ovn-channel 20.12/edge
+
+series: &series focal
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+    channel: *ceph-channel
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=4096
+    channel: *ceph-channel
+  cinder:
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  cinder-ceph:
+    charm: ch:cinder-ceph
+    channel: *openstack-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  glance:
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  keystone:
+    charm: ch:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/edge
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+    channel: 8.0/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: 1.7/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    channel: *ovn-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+  neutron-api:
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+    channel: *openstack-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  nova-cloud-controller:
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+    channel: *openstack-channel
+  nova-compute:
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+    channel: *openstack-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement:
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  rabbitmq-server:
+    charm: ch:rabbitmq-server
+    num_units: 1
+    constraints: mem=1024
+    channel: 3.8/edge
+  glance-simplestreams-sync:
+    charm: ch:glance-simplestreams-sync
+    num_units: 1
+    options:
+      use_swift: true
+    constraints: root-disk=8G
+    channel: *openstack-channel
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - vault:certificates
+  - glance-simplestreams-sync:certificates
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates

--- a/tests/distro-regression/tests/bundles/focal-wallaby-magnum.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby-magnum.yaml
@@ -1,0 +1,1 @@
+focal-wallaby-base.yaml

--- a/tests/distro-regression/tests/bundles/focal-xena-base.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena-base.yaml
@@ -1,0 +1,315 @@
+variables:
+  source: &source cloud:focal-xena/proposed
+  openstack-origin: &openstack-origin cloud:focal-xena/proposed
+  openstack-channel: &openstack-channel xena/edge
+  ceph-channel: &ceph-channel pacific/edge
+  ovn-channel: &ovn-channel 21.09/edge
+
+series: &series focal
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+    channel: *ceph-channel
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=4096
+    channel: *ceph-channel
+  cinder:
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  cinder-ceph:
+    charm: ch:cinder-ceph
+    channel: *openstack-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  glance:
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  keystone:
+    charm: ch:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/edge
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+    channel: 8.0/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: 1.7/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    channel: *ovn-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+  neutron-api:
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+    channel: *openstack-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  nova-cloud-controller:
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+    channel: *openstack-channel
+  nova-compute:
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+    channel: *openstack-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement:
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  rabbitmq-server:
+    charm: ch:rabbitmq-server
+    num_units: 1
+    constraints: mem=1024
+    channel: 3.8/edge
+  glance-simplestreams-sync:
+    charm: ch:glance-simplestreams-sync
+    num_units: 1
+    options:
+      use_swift: true
+    constraints: root-disk=8G
+    channel: *openstack-channel
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - vault:certificates
+  - glance-simplestreams-sync:certificates
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates

--- a/tests/distro-regression/tests/bundles/focal-xena-magnum.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena-magnum.yaml
@@ -1,0 +1,1 @@
+focal-xena-base.yaml

--- a/tests/distro-regression/tests/bundles/focal-yoga-base.yaml
+++ b/tests/distro-regression/tests/bundles/focal-yoga-base.yaml
@@ -1,0 +1,315 @@
+variables:
+  source: &source cloud:focal-yoga/proposed
+  openstack-origin: &openstack-origin cloud:focal-yoga/proposed
+  openstack-channel: &openstack-channel yoga/edge
+  ceph-channel: &ceph-channel quincy/edge
+  ovn-channel: &ovn-channel 22.03/edge
+
+series: &series focal
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+    channel: *ceph-channel
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=4096
+    channel: *ceph-channel
+  cinder:
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  cinder-ceph:
+    charm: ch:cinder-ceph
+    channel: *openstack-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  glance:
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  keystone:
+    charm: ch:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/edge
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+    channel: 8.0/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: 1.7/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    channel: *ovn-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+  neutron-api:
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+    channel: *openstack-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  nova-cloud-controller:
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+    channel: *openstack-channel
+  nova-compute:
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+    channel: *openstack-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement:
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  rabbitmq-server:
+    charm: ch:rabbitmq-server
+    num_units: 1
+    constraints: mem=1024
+    channel: 3.8/edge
+  glance-simplestreams-sync:
+    charm: ch:glance-simplestreams-sync
+    num_units: 1
+    options:
+      use_swift: true
+    constraints: root-disk=8G
+    channel: *openstack-channel
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - vault:certificates
+  - glance-simplestreams-sync:certificates
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates

--- a/tests/distro-regression/tests/bundles/focal-yoga-magnum.yaml
+++ b/tests/distro-regression/tests/bundles/focal-yoga-magnum.yaml
@@ -1,0 +1,1 @@
+focal-yoga-base.yaml

--- a/tests/distro-regression/tests/bundles/jammy-antelope-base.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-antelope-base.yaml
@@ -1,0 +1,315 @@
+variables:
+  source: &source cloud:jammy-antelope/proposed
+  openstack-origin: &openstack-origin cloud:jammy-antelope/proposed
+  openstack-channel: &openstack-channel latest/edge
+  ceph-channel: &ceph-channel latest/edge
+  ovn-channel: &ovn-channel latest/edge
+
+series: &series jammy
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+    channel: *ceph-channel
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=4096
+    channel: *ceph-channel
+  cinder:
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  cinder-ceph:
+    charm: ch:cinder-ceph
+    channel: *openstack-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  glance:
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  keystone:
+    charm: ch:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/edge
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+    channel: 8.0/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: 1.7/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    channel: *ovn-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+  neutron-api:
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+    channel: *openstack-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  nova-cloud-controller:
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+    channel: *openstack-channel
+  nova-compute:
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+    channel: *openstack-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement:
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  rabbitmq-server:
+    charm: ch:rabbitmq-server
+    num_units: 1
+    constraints: mem=1024
+    channel: 3.8/edge
+  glance-simplestreams-sync:
+    charm: ch:glance-simplestreams-sync
+    num_units: 1
+    options:
+      use_swift: true
+    constraints: root-disk=8G
+    channel: *openstack-channel
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - vault:certificates
+  - glance-simplestreams-sync:certificates
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates

--- a/tests/distro-regression/tests/bundles/jammy-antelope-magnum.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-antelope-magnum.yaml
@@ -1,0 +1,1 @@
+jammy-antelope-base.yaml

--- a/tests/distro-regression/tests/bundles/jammy-yoga-base.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga-base.yaml
@@ -1,0 +1,315 @@
+variables:
+  source: &source proposed
+  openstack-origin: &openstack-origin distro-proposed
+  openstack-channel: &openstack-channel yoga/edge
+  ceph-channel: &ceph-channel quincy/edge
+  ovn-channel: &ovn-channel 22.03/edge
+
+series: &series jammy
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+    channel: *ceph-channel
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=4096
+    channel: *ceph-channel
+  cinder:
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  cinder-ceph:
+    charm: ch:cinder-ceph
+    channel: *openstack-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  glance:
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  keystone:
+    charm: ch:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/edge
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+    channel: 8.0/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: 1.7/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    channel: *ovn-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+  neutron-api:
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+    channel: *openstack-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  nova-cloud-controller:
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+    channel: *openstack-channel
+  nova-compute:
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+    channel: *openstack-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement:
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  rabbitmq-server:
+    charm: ch:rabbitmq-server
+    num_units: 1
+    constraints: mem=1024
+    channel: 3.9/edge
+  glance-simplestreams-sync:
+    charm: ch:glance-simplestreams-sync
+    num_units: 1
+    options:
+      use_swift: true
+    constraints: root-disk=8G
+    channel: *openstack-channel
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - vault:certificates
+  - glance-simplestreams-sync:certificates
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates

--- a/tests/distro-regression/tests/bundles/jammy-yoga-magnum.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga-magnum.yaml
@@ -1,0 +1,1 @@
+jammy-yoga-base.yaml

--- a/tests/distro-regression/tests/bundles/jammy-zed-base.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed-base.yaml
@@ -1,0 +1,315 @@
+variables:
+  source: &source cloud:jammy-zed/proposed
+  openstack-origin: &openstack-origin cloud:jammy-zed/proposed
+  openstack-channel: &openstack-channel zed/edge
+  ceph-channel: &ceph-channel quincy/edge
+  ovn-channel: &ovn-channel 22.09/edge
+
+series: &series jammy
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+    channel: *ceph-channel
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=4096
+    channel: *ceph-channel
+  cinder:
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  cinder-ceph:
+    charm: ch:cinder-ceph
+    channel: *openstack-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  glance:
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  keystone:
+    charm: ch:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/edge
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+    channel: 8.0/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: 1.7/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    channel: *ovn-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+  neutron-api:
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+    channel: *openstack-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  nova-cloud-controller:
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+    channel: *openstack-channel
+  nova-compute:
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+    channel: *openstack-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement:
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  rabbitmq-server:
+    charm: ch:rabbitmq-server
+    num_units: 1
+    constraints: mem=1024
+    channel: 3.9/edge
+  glance-simplestreams-sync:
+    charm: ch:glance-simplestreams-sync
+    num_units: 1
+    options:
+      use_swift: true
+    constraints: root-disk=8G
+    channel: *openstack-channel
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - vault:certificates
+  - glance-simplestreams-sync:certificates
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates

--- a/tests/distro-regression/tests/bundles/jammy-zed-magnum.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed-magnum.yaml
@@ -1,0 +1,1 @@
+jammy-zed-base.yaml

--- a/tests/distro-regression/tests/bundles/kinetic-zed-base.yaml
+++ b/tests/distro-regression/tests/bundles/kinetic-zed-base.yaml
@@ -1,0 +1,316 @@
+variables:
+  source: &source proposed
+  openstack-origin: &openstack-origin distro-proposed
+  openstack-channel: &openstack-channel latest/edge
+  ceph-channel: &ceph-channel latest/edge
+  ovn-channel: &ovn-channel latest/edge
+
+series: &series kinetic
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+    channel: *ceph-channel
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=4096
+    channel: *ceph-channel
+  cinder:
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  cinder-ceph:
+    charm: ch:cinder-ceph
+    channel: *openstack-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  glance:
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  keystone:
+    charm: ch:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/stable
+    series: jammy
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+    channel: 8.0/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: 1.7/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    channel: *ovn-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+  neutron-api:
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+    channel: *openstack-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  nova-cloud-controller:
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+    channel: *openstack-channel
+  nova-compute:
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+    channel: *openstack-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement:
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  rabbitmq-server:
+    charm: ch:rabbitmq-server
+    num_units: 1
+    constraints: mem=1024
+    channel: 3.9/edge
+  glance-simplestreams-sync:
+    charm: ch:glance-simplestreams-sync
+    num_units: 1
+    options:
+      use_swift: true
+    constraints: root-disk=8G
+    channel: *openstack-channel
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - vault:certificates
+  - glance-simplestreams-sync:certificates
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates

--- a/tests/distro-regression/tests/bundles/kinetic-zed-magnum.yaml
+++ b/tests/distro-regression/tests/bundles/kinetic-zed-magnum.yaml
@@ -1,0 +1,1 @@
+kinetic-zed-base.yaml

--- a/tests/distro-regression/tests/bundles/lunar-antelope-base.yaml
+++ b/tests/distro-regression/tests/bundles/lunar-antelope-base.yaml
@@ -1,0 +1,316 @@
+variables:
+  source: &source proposed
+  openstack-origin: &openstack-origin distro-proposed
+  openstack-channel: &openstack-channel latest/edge
+  ceph-channel: &ceph-channel latest/edge
+  ovn-channel: &ovn-channel latest/edge
+
+series: &series lunar
+applications:
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+    channel: *ceph-channel
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,10G
+    constraints: mem=4096
+    channel: *ceph-channel
+  cinder:
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  cinder-ceph:
+    charm: ch:cinder-ceph
+    channel: *openstack-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: latest/edge
+  glance:
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: latest/edge
+  keystone:
+    charm: ch:keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: latest/edge
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/stable
+    series: jammy
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    constraints: mem=4096
+    channel: latest/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: 1.7/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: latest/edge
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    channel: *ovn-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    channel: *ovn-channel
+  neutron-api:
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      openstack-origin: *openstack-origin
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+    constraints: mem=1024
+    channel: *openstack-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: latest/edge
+  nova-cloud-controller:
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=2048
+    channel: *openstack-channel
+  nova-compute:
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+    channel: *openstack-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: latest/edge
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement:
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: latest/edge
+  rabbitmq-server:
+    charm: ch:rabbitmq-server
+    num_units: 1
+    constraints: mem=1024
+    channel: latest/edge
+  glance-simplestreams-sync:
+    charm: ch:glance-simplestreams-sync
+    num_units: 1
+    options:
+      use_swift: true
+    constraints: root-disk=8G
+    channel: *openstack-channel
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+    channel: *openstack-channel
+relations:
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - placement:identity-service
+  - keystone:identity-service
+- - placement:placement
+  - nova-cloud-controller:placement
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone:identity-service
+  - glance-simplestreams-sync:identity-service
+- - vault:certificates
+  - glance-simplestreams-sync:certificates
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates

--- a/tests/distro-regression/tests/bundles/lunar-antelope-magnum.yaml
+++ b/tests/distro-regression/tests/bundles/lunar-antelope-magnum.yaml
@@ -1,0 +1,1 @@
+lunar-antelope-base.yaml

--- a/tests/distro-regression/tests/bundles/overlays/focal-ussuri-magnum.yaml.j2
+++ b/tests/distro-regression/tests/bundles/overlays/focal-ussuri-magnum.yaml.j2
@@ -1,0 +1,84 @@
+# -*- mode: yaml -*-
+variables:
+  source: &source proposed
+  openstack-origin: &openstack-origin distro-proposed
+  openstack-channel: &openstack-channel ussuri/edge
+
+series: &series focal
+applications:
+  barbican:
+    charm: ch:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  barbican-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  heat:
+    charm: ch:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  heat-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum:
+    charm: ch:magnum
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  magnum-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum-dashboard:
+    charm: ch:magnum-dashboard
+    channel: *openstack-channel
+
+  # these applications are defined in the main bundle, they are defined here
+  # to allow them to be referenced in the relation within this overlay
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+  keystone:
+    charm: ch:keystone
+  vault:
+    charm: ch:vault
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+
+relations:
+- - 'magnum:shared-db'
+  - 'magnum-mysql-router:shared-db'
+- - 'magnum-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'magnum:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'magnum:identity-service'
+  - 'keystone:identity-service'
+- - 'magnum:certificates'
+  - 'vault:certificates'
+- - 'heat:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'heat:identity-service'
+  - 'keystone:identity-service'
+- - 'heat:shared-db'
+  - 'heat-mysql-router:shared-db'
+- - 'heat-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'heat:certificates'
+  - 'vault:certificates'
+- - 'barbican:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'barbican:identity-service'
+  - 'keystone:identity-service'
+- - 'barbican:shared-db'
+  - 'barbican-mysql-router:shared-db'
+- - 'barbican-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'barbican:certificates'
+  - 'vault:certificates'
+- - 'openstack-dashboard:dashboard-plugin'
+  - 'magnum-dashboard:dashboard'

--- a/tests/distro-regression/tests/bundles/overlays/focal-victoria-magnum.yaml.j2
+++ b/tests/distro-regression/tests/bundles/overlays/focal-victoria-magnum.yaml.j2
@@ -1,0 +1,84 @@
+# -*- mode: yaml -*-
+variables:
+  source: &source cloud:focal-victoria/proposed
+  openstack-origin: &openstack-origin cloud:focal-victoria/proposed
+  openstack-channel: &openstack-channel victoria/edge
+
+series: &series focal
+applications:
+  barbican:
+    charm: ch:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  barbican-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  heat:
+    charm: ch:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  heat-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum:
+    charm: ch:magnum
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  magnum-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum-dashboard:
+    charm: ch:magnum-dashboard
+    channel: *openstack-channel
+
+  # these applications are defined in the main bundle, they are defined here
+  # to allow them to be referenced in the relation within this overlay
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+  keystone:
+    charm: ch:keystone
+  vault:
+    charm: ch:vault
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+
+relations:
+- - 'magnum:shared-db'
+  - 'magnum-mysql-router:shared-db'
+- - 'magnum-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'magnum:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'magnum:identity-service'
+  - 'keystone:identity-service'
+- - 'magnum:certificates'
+  - 'vault:certificates'
+- - 'heat:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'heat:identity-service'
+  - 'keystone:identity-service'
+- - 'heat:shared-db'
+  - 'heat-mysql-router:shared-db'
+- - 'heat-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'heat:certificates'
+  - 'vault:certificates'
+- - 'barbican:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'barbican:identity-service'
+  - 'keystone:identity-service'
+- - 'barbican:shared-db'
+  - 'barbican-mysql-router:shared-db'
+- - 'barbican-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'barbican:certificates'
+  - 'vault:certificates'
+- - 'openstack-dashboard:dashboard-plugin'
+  - 'magnum-dashboard:dashboard'

--- a/tests/distro-regression/tests/bundles/overlays/focal-wallaby-magnum.yaml.j2
+++ b/tests/distro-regression/tests/bundles/overlays/focal-wallaby-magnum.yaml.j2
@@ -1,0 +1,84 @@
+# -*- mode: yaml -*-
+variables:
+  source: &source cloud:focal-wallaby/proposed
+  openstack-origin: &openstack-origin cloud:focal-wallaby/proposed
+  openstack-channel: &openstack-channel wallaby/edge
+
+series: &series focal
+applications:
+  barbican:
+    charm: ch:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  barbican-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  heat:
+    charm: ch:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  heat-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum:
+    charm: ch:magnum
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  magnum-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum-dashboard:
+    charm: ch:magnum-dashboard
+    channel: *openstack-channel
+
+  # these applications are defined in the main bundle, they are defined here
+  # to allow them to be referenced in the relation within this overlay
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+  keystone:
+    charm: ch:keystone
+  vault:
+    charm: ch:vault
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+
+relations:
+- - 'magnum:shared-db'
+  - 'magnum-mysql-router:shared-db'
+- - 'magnum-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'magnum:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'magnum:identity-service'
+  - 'keystone:identity-service'
+- - 'magnum:certificates'
+  - 'vault:certificates'
+- - 'heat:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'heat:identity-service'
+  - 'keystone:identity-service'
+- - 'heat:shared-db'
+  - 'heat-mysql-router:shared-db'
+- - 'heat-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'heat:certificates'
+  - 'vault:certificates'
+- - 'barbican:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'barbican:identity-service'
+  - 'keystone:identity-service'
+- - 'barbican:shared-db'
+  - 'barbican-mysql-router:shared-db'
+- - 'barbican-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'barbican:certificates'
+  - 'vault:certificates'
+- - 'openstack-dashboard:dashboard-plugin'
+  - 'magnum-dashboard:dashboard'

--- a/tests/distro-regression/tests/bundles/overlays/focal-xena-magnum.yaml.j2
+++ b/tests/distro-regression/tests/bundles/overlays/focal-xena-magnum.yaml.j2
@@ -1,0 +1,84 @@
+# -*- mode: yaml -*-
+variables:
+  source: &source cloud:focal-xena/proposed
+  openstack-origin: &openstack-origin cloud:focal-xena/proposed
+  openstack-channel: &openstack-channel xena/edge
+
+series: &series focal
+applications:
+  barbican:
+    charm: ch:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  barbican-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  heat:
+    charm: ch:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  heat-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum:
+    charm: ch:magnum
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  magnum-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum-dashboard:
+    charm: ch:magnum-dashboard
+    channel: *openstack-channel
+
+  # these applications are defined in the main bundle, they are defined here
+  # to allow them to be referenced in the relation within this overlay
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+  keystone:
+    charm: ch:keystone
+  vault:
+    charm: ch:vault
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+
+relations:
+- - 'magnum:shared-db'
+  - 'magnum-mysql-router:shared-db'
+- - 'magnum-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'magnum:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'magnum:identity-service'
+  - 'keystone:identity-service'
+- - 'magnum:certificates'
+  - 'vault:certificates'
+- - 'heat:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'heat:identity-service'
+  - 'keystone:identity-service'
+- - 'heat:shared-db'
+  - 'heat-mysql-router:shared-db'
+- - 'heat-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'heat:certificates'
+  - 'vault:certificates'
+- - 'barbican:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'barbican:identity-service'
+  - 'keystone:identity-service'
+- - 'barbican:shared-db'
+  - 'barbican-mysql-router:shared-db'
+- - 'barbican-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'barbican:certificates'
+  - 'vault:certificates'
+- - 'openstack-dashboard:dashboard-plugin'
+  - 'magnum-dashboard:dashboard'

--- a/tests/distro-regression/tests/bundles/overlays/focal-yoga-magnum.yaml.j2
+++ b/tests/distro-regression/tests/bundles/overlays/focal-yoga-magnum.yaml.j2
@@ -1,0 +1,84 @@
+# -*- mode: yaml -*-
+variables:
+  source: &source cloud:focal-yoga/proposed
+  openstack-origin: &openstack-origin cloud:focal-yoga/proposed
+  openstack-channel: &openstack-channel yoga/edge
+
+series: &series focal
+applications:
+  barbican:
+    charm: ch:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  barbican-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  heat:
+    charm: ch:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  heat-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum:
+    charm: ch:magnum
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  magnum-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum-dashboard:
+    charm: ch:magnum-dashboard
+    channel: *openstack-channel
+
+  # these applications are defined in the main bundle, they are defined here
+  # to allow them to be referenced in the relation within this overlay
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+  keystone:
+    charm: ch:keystone
+  vault:
+    charm: ch:vault
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+
+relations:
+- - 'magnum:shared-db'
+  - 'magnum-mysql-router:shared-db'
+- - 'magnum-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'magnum:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'magnum:identity-service'
+  - 'keystone:identity-service'
+- - 'magnum:certificates'
+  - 'vault:certificates'
+- - 'heat:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'heat:identity-service'
+  - 'keystone:identity-service'
+- - 'heat:shared-db'
+  - 'heat-mysql-router:shared-db'
+- - 'heat-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'heat:certificates'
+  - 'vault:certificates'
+- - 'barbican:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'barbican:identity-service'
+  - 'keystone:identity-service'
+- - 'barbican:shared-db'
+  - 'barbican-mysql-router:shared-db'
+- - 'barbican-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'barbican:certificates'
+  - 'vault:certificates'
+- - 'openstack-dashboard:dashboard-plugin'
+  - 'magnum-dashboard:dashboard'

--- a/tests/distro-regression/tests/bundles/overlays/jammy-antelope-magnum.yaml.j2
+++ b/tests/distro-regression/tests/bundles/overlays/jammy-antelope-magnum.yaml.j2
@@ -1,0 +1,84 @@
+# -*- mode: yaml -*-
+variables:
+  source: &source cloud:jammy-antelope/proposed
+  openstack-origin: &openstack-origin cloud:jammy-antelope/proposed
+  openstack-channel: &openstack-channel latest/edge
+
+series: &series jammy
+applications:
+  barbican:
+    charm: ch:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  barbican-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  heat:
+    charm: ch:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  heat-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum:
+    charm: ch:magnum
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  magnum-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum-dashboard:
+    charm: ch:magnum-dashboard
+    channel: *openstack-channel
+
+  # these applications are defined in the main bundle, they are defined here
+  # to allow them to be referenced in the relation within this overlay
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+  keystone:
+    charm: ch:keystone
+  vault:
+    charm: ch:vault
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+
+relations:
+- - 'magnum:shared-db'
+  - 'magnum-mysql-router:shared-db'
+- - 'magnum-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'magnum:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'magnum:identity-service'
+  - 'keystone:identity-service'
+- - 'magnum:certificates'
+  - 'vault:certificates'
+- - 'heat:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'heat:identity-service'
+  - 'keystone:identity-service'
+- - 'heat:shared-db'
+  - 'heat-mysql-router:shared-db'
+- - 'heat-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'heat:certificates'
+  - 'vault:certificates'
+- - 'barbican:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'barbican:identity-service'
+  - 'keystone:identity-service'
+- - 'barbican:shared-db'
+  - 'barbican-mysql-router:shared-db'
+- - 'barbican-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'barbican:certificates'
+  - 'vault:certificates'
+- - 'openstack-dashboard:dashboard-plugin'
+  - 'magnum-dashboard:dashboard'

--- a/tests/distro-regression/tests/bundles/overlays/jammy-yoga-magnum.yaml.j2
+++ b/tests/distro-regression/tests/bundles/overlays/jammy-yoga-magnum.yaml.j2
@@ -1,0 +1,84 @@
+# -*- mode: yaml -*-
+variables:
+  source: &source proposed
+  openstack-origin: &openstack-origin distro-proposed
+  openstack-channel: &openstack-channel yoga/edge
+
+series: &series jammy
+applications:
+  barbican:
+    charm: ch:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  barbican-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  heat:
+    charm: ch:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  heat-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum:
+    charm: ch:magnum
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  magnum-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum-dashboard:
+    charm: ch:magnum-dashboard
+    channel: *openstack-channel
+
+  # these applications are defined in the main bundle, they are defined here
+  # to allow them to be referenced in the relation within this overlay
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+  keystone:
+    charm: ch:keystone
+  vault:
+    charm: ch:vault
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+
+relations:
+- - 'magnum:shared-db'
+  - 'magnum-mysql-router:shared-db'
+- - 'magnum-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'magnum:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'magnum:identity-service'
+  - 'keystone:identity-service'
+- - 'magnum:certificates'
+  - 'vault:certificates'
+- - 'heat:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'heat:identity-service'
+  - 'keystone:identity-service'
+- - 'heat:shared-db'
+  - 'heat-mysql-router:shared-db'
+- - 'heat-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'heat:certificates'
+  - 'vault:certificates'
+- - 'barbican:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'barbican:identity-service'
+  - 'keystone:identity-service'
+- - 'barbican:shared-db'
+  - 'barbican-mysql-router:shared-db'
+- - 'barbican-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'barbican:certificates'
+  - 'vault:certificates'
+- - 'openstack-dashboard:dashboard-plugin'
+  - 'magnum-dashboard:dashboard'

--- a/tests/distro-regression/tests/bundles/overlays/jammy-zed-magnum.yaml.j2
+++ b/tests/distro-regression/tests/bundles/overlays/jammy-zed-magnum.yaml.j2
@@ -1,0 +1,84 @@
+# -*- mode: yaml -*-
+variables:
+  source: &source cloud:jammy-zed/proposed
+  openstack-origin: &openstack-origin cloud:jammy-zed/proposed
+  openstack-channel: &openstack-channel zed/edge
+
+series: &series jammy
+applications:
+  barbican:
+    charm: ch:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  barbican-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  heat:
+    charm: ch:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  heat-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum:
+    charm: ch:magnum
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  magnum-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum-dashboard:
+    charm: ch:magnum-dashboard
+    channel: *openstack-channel
+
+  # these applications are defined in the main bundle, they are defined here
+  # to allow them to be referenced in the relation within this overlay
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+  keystone:
+    charm: ch:keystone
+  vault:
+    charm: ch:vault
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+
+relations:
+- - 'magnum:shared-db'
+  - 'magnum-mysql-router:shared-db'
+- - 'magnum-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'magnum:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'magnum:identity-service'
+  - 'keystone:identity-service'
+- - 'magnum:certificates'
+  - 'vault:certificates'
+- - 'heat:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'heat:identity-service'
+  - 'keystone:identity-service'
+- - 'heat:shared-db'
+  - 'heat-mysql-router:shared-db'
+- - 'heat-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'heat:certificates'
+  - 'vault:certificates'
+- - 'barbican:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'barbican:identity-service'
+  - 'keystone:identity-service'
+- - 'barbican:shared-db'
+  - 'barbican-mysql-router:shared-db'
+- - 'barbican-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'barbican:certificates'
+  - 'vault:certificates'
+- - 'openstack-dashboard:dashboard-plugin'
+  - 'magnum-dashboard:dashboard'

--- a/tests/distro-regression/tests/bundles/overlays/kinetic-zed-magnum.yaml.j2
+++ b/tests/distro-regression/tests/bundles/overlays/kinetic-zed-magnum.yaml.j2
@@ -1,0 +1,84 @@
+# -*- mode: yaml -*-
+variables:
+  source: &source proposed
+  openstack-origin: &openstack-origin distro-proposed
+  openstack-channel: &openstack-channel zed/edge
+
+series: &series kinetic
+applications:
+  barbican:
+    charm: ch:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  barbican-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  heat:
+    charm: ch:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  heat-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum:
+    charm: ch:magnum
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  magnum-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum-dashboard:
+    charm: ch:magnum-dashboard
+    channel: *openstack-channel
+
+  # these applications are defined in the main bundle, they are defined here
+  # to allow them to be referenced in the relation within this overlay
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+  keystone:
+    charm: ch:keystone
+  vault:
+    charm: ch:vault
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+
+relations:
+- - 'magnum:shared-db'
+  - 'magnum-mysql-router:shared-db'
+- - 'magnum-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'magnum:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'magnum:identity-service'
+  - 'keystone:identity-service'
+- - 'magnum:certificates'
+  - 'vault:certificates'
+- - 'heat:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'heat:identity-service'
+  - 'keystone:identity-service'
+- - 'heat:shared-db'
+  - 'heat-mysql-router:shared-db'
+- - 'heat-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'heat:certificates'
+  - 'vault:certificates'
+- - 'barbican:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'barbican:identity-service'
+  - 'keystone:identity-service'
+- - 'barbican:shared-db'
+  - 'barbican-mysql-router:shared-db'
+- - 'barbican-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'barbican:certificates'
+  - 'vault:certificates'
+- - 'openstack-dashboard:dashboard-plugin'
+  - 'magnum-dashboard:dashboard'

--- a/tests/distro-regression/tests/bundles/overlays/lunar-antelope-magnum.yaml.j2
+++ b/tests/distro-regression/tests/bundles/overlays/lunar-antelope-magnum.yaml.j2
@@ -1,0 +1,84 @@
+# -*- mode: yaml -*-
+variables:
+  source: &source proposed
+  openstack-origin: &openstack-origin distro-proposed
+  openstack-channel: &openstack-channel latest/edge
+
+series: &series lunar
+applications:
+  barbican:
+    charm: ch:barbican
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+    channel: *openstack-channel
+  barbican-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  heat:
+    charm: ch:heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  heat-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum:
+    charm: ch:magnum
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    channel: *openstack-channel
+  magnum-mysql-router:
+    charm: ch:mysql-router
+    channel: 8.0/edge
+  magnum-dashboard:
+    charm: ch:magnum-dashboard
+    channel: *openstack-channel
+
+  # these applications are defined in the main bundle, they are defined here
+  # to allow them to be referenced in the relation within this overlay
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+  keystone:
+    charm: ch:keystone
+  vault:
+    charm: ch:vault
+  openstack-dashboard:
+    charm: ch:openstack-dashboard
+
+relations:
+- - 'magnum:shared-db'
+  - 'magnum-mysql-router:shared-db'
+- - 'magnum-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'magnum:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'magnum:identity-service'
+  - 'keystone:identity-service'
+- - 'magnum:certificates'
+  - 'vault:certificates'
+- - 'heat:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'heat:identity-service'
+  - 'keystone:identity-service'
+- - 'heat:shared-db'
+  - 'heat-mysql-router:shared-db'
+- - 'heat-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'heat:certificates'
+  - 'vault:certificates'
+- - 'barbican:amqp'
+  - 'rabbitmq-server:amqp'
+- - 'barbican:identity-service'
+  - 'keystone:identity-service'
+- - 'barbican:shared-db'
+  - 'barbican-mysql-router:shared-db'
+- - 'barbican-mysql-router:db-router'
+  - 'mysql-innodb-cluster:db-router'
+- - 'barbican:certificates'
+  - 'vault:certificates'
+- - 'openstack-dashboard:dashboard-plugin'
+  - 'magnum-dashboard:dashboard'

--- a/tests/distro-regression/tests/tests.yaml
+++ b/tests/distro-regression/tests/tests.yaml
@@ -14,6 +14,16 @@ smoke_bundles:
   - keystone_v3_smoke_focal: jammy-antelope
   - keystone_v3_smoke_focal: kinetic-zed
   - keystone_v3_smoke_focal: lunar-antelope
+  - keystone_v3_smoke_focal_magnum: focal-ussuri-magnum
+  - keystone_v3_smoke_focal_magnum: focal-victoria-magnum
+  - keystone_v3_smoke_focal_magnum: focal-wallaby-magnum
+  - keystone_v3_smoke_focal_magnum: focal-xena-magnum
+  - keystone_v3_smoke_focal_magnum: focal-yoga-magnum
+  - keystone_v3_smoke_focal_magnum: jammy-yoga-magnum
+  - keystone_v3_smoke_focal_magnum: jammy-zed-magnum
+  - keystone_v3_smoke_focal_magnum: jammy-antelope-magnum
+  - keystone_v3_smoke_focal_magnum: kinetic-zed-magnum
+  - keystone_v3_smoke_focal_magnum: lunar-antelope-magnum
 configure:
   - keystone_v2_smoke: &configure_queens_and_older
     - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
@@ -58,6 +68,20 @@ configure:
     - zaza.openstack.charm_tests.glance.setup.add_cirros_image
     - zaza.openstack.charm_tests.glance.setup.add_cirros_alt_image
     - zaza.openstack.charm_tests.octavia.setup.centralized_fip_network
+  - keystone_v3_smoke_focal_magnum:
+    - zaza.openstack.charm_tests.vault.setup.auto_initialize
+    - zaza.openstack.charm_tests.glance_simplestreams_sync.setup.sync_images
+    - zaza.openstack.charm_tests.glance.setup.add_lts_image
+    - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+    - zaza.openstack.charm_tests.nova.setup.create_flavors
+    - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+    - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+    - zaza.openstack.charm_tests.keystone.setup.add_tempest_roles
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_image
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_alt_image
+    - zaza.openstack.charm_tests.heat.setup.domain_setup
+    - zaza.openstack.charm_tests.magnum.setup.domain_setup
+    - zaza.openstack.charm_tests.magnum.setup.add_image
 tests:
   - keystone_v2_smoke:
     - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV2
@@ -68,6 +92,8 @@ tests:
   - keystone_v3_smoke_stein:
     - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
   - keystone_v3_smoke_focal:
+    - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
+  - keystone_v3_smoke_focal_magnum:
     - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
 tests_options:
   tempest:
@@ -94,6 +120,24 @@ tests_options:
         - "manila_tempest_tests.tests.api.admin.test_share_networks.ShareNetworkAdminTest"
         - "manila_tempest_tests.tests.api.test_share_networks.ShareNetworksTest"
         - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest"
+    keystone_v3_smoke_focal_magnum:
+      smoke: True
+      include-list:
+        - "magnum_tempest_plugin.tests.api.v1.test_cluster"
+        - "magnum_tempest_plugin.tests.api.v1.test_cluster_template"
+        - "magnum_tempest_plugin.tests.api.v1.test_cluster_template_admin"
+        - "magnum_tempest_plugin.tests.api.v1.test_magnum_service"
+      exclude-list:
+        # Implemented on container-infra 1.10 which is available in >=Xena
+        # https://opendev.org/openstack/magnum/commit/0e6d17893
+        # https://opendev.org/openstack/magnum-tempest-plugin/commit/b68a678f37de0a769e7ee8dbefa9bdfe6cf445cc
+        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_list_sign_delete_clusters"
+        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_zero_nodes"
+        # The test expects a 400 error while the server returns a 401 error due to glance
+        # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
+        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
+      exclude-regex:
+        - "^(octavia_tempest_plugin|manila_tempest_tests|designate_tempest_plugin)\\..*"
   force_deploy:
     - bionic-queens
     - bionic-rocky
@@ -105,25 +149,25 @@ tests_options:
 target_deploy_status:
   ceilometer:
     workload-status: blocked
-    workload-status-message: "Run the ceilometer-upgrade action on the leader to initialize ceilometer and gnocchi"
+    workload-status-message-prefix: "Run the ceilometer-upgrade action on the leader to initialize ceilometer and gnocchi"
   glance-simplestreams-sync:
     workload-status: unknown
-    workload-status-message: ""
+    workload-status-message-prefix: ""
   mongodb:
     workload-status: unknown
-    workload-status-message: ""
+    workload-status-message-prefix: ""
   neutron-api-plugin-ovn:
     workload-status: waiting
-    workload-status-message: "'certificates' awaiting server certificate data, 'ovsdb-cms' incomplete"
+    workload-status-message-prefix: "'certificates' awaiting server certificate data, 'ovsdb-cms' incomplete"
   octavia:
     workload-status: blocked
-    workload-status-message: Awaiting
+    workload-status-message-prefix: Awaiting
   ovn-central:
     workload-status: waiting
-    workload-status-message: "'ovsdb-peer' incomplete, 'certificates' awaiting server certificate data"
+    workload-status-message-prefix: "'ovsdb-peer' incomplete, 'certificates' awaiting server certificate data"
   ovn-chassis:
     workload-status: waiting
-    workload-status-message: "'certificates' awaiting server certificate data"
+    workload-status-message-prefix: "'certificates' awaiting server certificate data"
   vault:
     workload-status: blocked
-    workload-status-message: Vault needs to be initialized
+    workload-status-message-prefix: Vault needs to be initialized


### PR DESCRIPTION
Introduce new targets to deploy Magnum

List of changes:
- Use workload-status-message-prefix, workload-status-message has been deprecated.
- Include magnum_tempest_plugin in the list of tests to run.
- Disable tests with known failures:
  + test_create_list_sign_delete_clusters
  + test_create_cluster_with_zero_nodes: relies on microversion 1.10, while Ussuri's max microversion is 1.9.
  + test_create_cluster_with_nonexisting_flavor: expects a 400 error while the server returns a 401 error

The list of disabled tests is consistent with what other deployment projects have done[0].

List of targets:

- focal-ussuri
- focal-victoria
- focal-wallaby
- focal-xena
- focal-yoga
- jammy-yoga
- jammy-zed
- kinetic-zed
- lunar-zed

[0] https://opendev.org/openstack/openstack-ansible/src/branch/master/tests/roles/bootstrap-host/templates/user_variables_magnum.yml.j2#L61-L64