### PR TITLE
Add example for setting up overlay PPA

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,17 @@ Common setup:
   export TEST_CIDR_PRIV=192.168.21.0/24
   export TEST_SWIFT_IP=10.245.161.162
 
+Set up an overlay PPA on each machine in the model:
+
+.. code-block:: bash
+
+  export OVERLAY_PPA="ppa:ubuntu-security-proposed/ppa"
+  export TEST_MODEL_SETTINGS=cloudinit-userdata="#cloud-config
+  apt:
+    sources:
+      overlay-ppa:
+        source: \"$OVERLAY_PPA\""
+
 Deploy and test a specific bundle:
 
 .. code-block:: bash


### PR DESCRIPTION
The example added to the README uses the TEST_MODEL_SETTINGS environment variable to specify an overlay PPA that will be configured on each machine in the zaza model.