### PR TITLE
Increase nova-cloud-controller memory constraints

### DIFF
--- a/tests/distro-regression/tests/bundles/bionic-queens.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-queens.yaml
@@ -139,7 +139,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: queens/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/bionic-rocky.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-rocky.yaml
@@ -147,7 +147,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: rocky/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/bionic-stein.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-stein.yaml
@@ -147,7 +147,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: stein/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/bionic-train.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-train.yaml
@@ -147,7 +147,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: train/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
@@ -149,7 +149,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: ussuri/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -174,7 +174,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: ussuri/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -175,7 +175,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: victoria/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/focal-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby.yaml
@@ -201,7 +201,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: wallaby/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/focal-xena.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena.yaml
@@ -201,7 +201,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: xena/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/focal-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/focal-yoga.yaml
@@ -201,7 +201,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: yoga/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/jammy-antelope.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-antelope.yaml
@@ -208,7 +208,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: *openstack-channel
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/jammy-bobcat.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-bobcat.yaml
@@ -208,7 +208,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: *openstack-channel
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/jammy-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga.yaml
@@ -200,7 +200,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: yoga/edge
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/jammy-zed.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed.yaml
@@ -208,7 +208,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: *openstack-channel
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/kinetic-zed.yaml
+++ b/tests/distro-regression/tests/bundles/kinetic-zed.yaml
@@ -223,7 +223,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: *openstack-channel
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/lunar-antelope.yaml
+++ b/tests/distro-regression/tests/bundles/lunar-antelope.yaml
@@ -223,7 +223,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: *openstack-channel
   nova-compute:
     charm: ch:nova-compute

--- a/tests/distro-regression/tests/bundles/mantic-bobcat.yaml
+++ b/tests/distro-regression/tests/bundles/mantic-bobcat.yaml
@@ -223,7 +223,7 @@ applications:
     options:
       network-manager: Neutron
       openstack-origin: *openstack-origin
-    constraints: mem=2048
+    constraints: mem=4096
     channel: *openstack-channel
   nova-compute:
     charm: ch:nova-compute


### PR DESCRIPTION
nova-cloud-controller was recently found to be hitting oom issues so this increases the memory contraints.