### PR TITLE
Update demo novarc credentials and add demo ssl novarc

### DIFF
--- a/scripts/novarcv3_ssl_demo_project
+++ b/scripts/novarcv3_ssl_demo_project
@@ -6,8 +6,15 @@ for param in $_OS_PARAMS; do
 done
 unset _OS_PARAMS
 
-_keystone_ip=$(juju run $_juju_model_arg --unit keystone/leader 'unit-get private-address')
+# openstackclients snap can't read files outside the home directory.
+test -d $HOME/.cache || mkdir $HOME/.cache
+_root_ca=$HOME/.cache/openstack-root-ca.crt
 
+_keystone_ip=$(juju run $_juju_model_arg --unit keystone/leader 'unit-get private-address')
+juju run $_juju_model_arg --unit vault/leader 'leader-get root-ca' > ${_root_ca}
+
+export OS_AUTH_PROTOCOL=https
+export OS_CACERT=${_root_ca}
 export OS_AUTH_URL=${OS_AUTH_PROTOCOL:-http}://${_keystone_ip}:5000/v3
 export OS_USERNAME=demo
 export OS_PASSWORD=password
@@ -16,7 +23,7 @@ export OS_PROJECT_DOMAIN_NAME=demoDomain
 export OS_PROJECT_NAME=demoProject
 export OS_REGION_NAME=RegionOne
 export OS_IDENTITY_API_VERSION=3
-# Swift needs this:
+# Swift needs this
 export OS_AUTH_VERSION=3
 # Gnocchi needs this
 export OS_AUTH_TYPE=password


### PR DESCRIPTION
The demo credentials have changed in zaza-openstack-tests since this script was created. Also add an SSL version of the script for the demo user.