### PR TITLE
Pin juju client to 2.9 for the linting tests.

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -14,7 +14,7 @@ jobs:
         set -euxo pipefail
         python -m pip install --upgrade pip
         pip install tox
-        sudo snap install --classic juju
+        sudo snap install --classic juju --channel=2.9/stable
         sudo lxd init --auto
         # This is a throw-away CI environment, do not do this at home
         sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket


### PR DESCRIPTION
This will need to be reviewed overtime with consideration to linting
with both 2.9 and 3.1/3.3 depending on which becomes the next 'LTS' for
Juju.
