### PR TITLE
Enable testing of Security Proposed PPA

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -23,7 +23,7 @@ jobs:
         # iptables updates to allow traffic to/from LXD bridge/external network
         sudo iptables -I DOCKER-USER -i lxdbr0 -o eth0 -j ACCEPT
         sudo iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-        juju bootstrap --no-gui localhost
+        juju bootstrap localhost
     - name: Bundle validation with tox using dry-run juju deploy
       run: tox -e lint
     - name: consider debugging

--- a/osci.yaml
+++ b/osci.yaml
@@ -1,6 +1,9 @@
 - semaphore:
     name: distro-regression
     max: 2
+- semaphore:
+    name: security-distro-regression
+    max: 2
 - project:
     periodic-weekly:
       jobs:
@@ -17,6 +20,12 @@
       - cot_distro-regression_focal-yoga
       - cot_distro-regression_jammy-yoga
       - cot_distro-regression_jammy-zed
+      - cot_distro-regression_jammy-antelope
+      - cot_distro-regression_lunar-antelope
+      - cot_security-distro-regression_bionic-queens
+      - cot_security-distro-regression_focal-ussuri
+      - cot_security-distro-regression_jammy-yoga
+      - cot_security-distro-regression_lunar-antelope
 - job:
     name: cot-func-target
     parent: func-target
@@ -95,5 +104,30 @@
 - job:
     name: cot_distro-regression_lunar-antelope
     parent: cot-func-target
+    vars:
+      tox_extra_args: '-- lunar-antelope'
+- job:
+    name: cot-security-distro-regression
+    parent: security-distro-regression
+    semaphore: security-distro-regression
+    abstract: true
+- job:
+    name: cot_security-distro-regression_bionic-queens
+    parent: cot-security-distro-regression
+    vars:
+      tox_extra_args: '-- bionic-queens'
+- job:
+    name: cot_security-distro-regression_focal-ussuri
+    parent: cot-security-distro-regression
+    vars:
+      tox_extra_args: '-- focal-ussuri'
+- job:
+    name: cot_security-distro-regression_jammy-yoga
+    parent: cot-security-distro-regression
+    vars:
+      tox_extra_args: '-- jammy-yoga'
+- job:
+    name: cot_security-distro-regression_lunar-antelope
+    parent: cot-security-distro-regression
     vars:
       tox_extra_args: '-- lunar-antelope'

--- a/tests/security-distro-regression/tests/bundles/bionic-queens.yaml
+++ b/tests/security-distro-regression/tests/bundles/bionic-queens.yaml
@@ -1,0 +1,1 @@
+../../../distro-regression/tests/bundles/bionic-queens.yaml

--- a/tests/security-distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/security-distro-regression/tests/bundles/focal-ussuri.yaml
@@ -1,0 +1,1 @@
+../../../distro-regression/tests/bundles/focal-ussuri.yaml

--- a/tests/security-distro-regression/tests/bundles/jammy-yoga.yaml
+++ b/tests/security-distro-regression/tests/bundles/jammy-yoga.yaml
@@ -1,0 +1,1 @@
+../../../distro-regression/tests/bundles/jammy-yoga.yaml

--- a/tests/security-distro-regression/tests/bundles/lunar-antelope.yaml
+++ b/tests/security-distro-regression/tests/bundles/lunar-antelope.yaml
@@ -1,0 +1,1 @@
+../../../distro-regression/tests/bundles/lunar-antelope.yaml

--- a/tests/security-distro-regression/tests/bundles/mantic-bobcat.yaml
+++ b/tests/security-distro-regression/tests/bundles/mantic-bobcat.yaml
@@ -1,0 +1,1 @@
+../../../distro-regression/tests/bundles/mantic-bobcat.yaml

--- a/tests/security-distro-regression/tests/tests.yaml
+++ b/tests/security-distro-regression/tests/tests.yaml
@@ -1,0 +1,85 @@
+smoke_bundles:
+  - keystone_v3_smoke_security: bionic-queens
+  - keystone_v3_smoke_focal_security: focal-ussuri
+  - keystone_v3_smoke_focal_security: jammy-yoga
+  - keystone_v3_smoke_focal_security: lunar-antelope
+  - keystone_v3_smoke_focal_security: mantic-bobcat
+configure:
+  - keystone_v3_smoke_security:
+    - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
+    - zaza.openstack.charm_tests.glance.setup.add_lts_image
+    - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+    - zaza.openstack.charm_tests.nova.setup.create_flavors
+    - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+    - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+    - zaza.openstack.charm_tests.keystone.setup.add_tempest_roles
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_image
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_alt_image
+  - keystone_v3_smoke_focal_security:
+    - zaza.openstack.charm_tests.vault.setup.auto_initialize
+    - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
+    - zaza.openstack.charm_tests.glance_simplestreams_sync.setup.sync_images
+    - zaza.openstack.charm_tests.glance.setup.add_lts_image
+    - zaza.openstack.charm_tests.octavia.setup.ensure_lts_images
+    - zaza.openstack.charm_tests.octavia.diskimage_retrofit.setup.retrofit_amphora_image
+    - zaza.openstack.charm_tests.octavia.setup.configure_octavia
+    - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
+    - zaza.openstack.charm_tests.nova.setup.create_flavors
+    - zaza.openstack.charm_tests.nova.setup.manage_ssh_key
+    - zaza.openstack.charm_tests.keystone.setup.add_demo_user
+    - zaza.openstack.charm_tests.keystone.setup.add_tempest_roles
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_image
+    - zaza.openstack.charm_tests.glance.setup.add_cirros_alt_image
+    - zaza.openstack.charm_tests.octavia.setup.centralized_fip_network
+tests:
+  - keystone_v3_smoke_security:
+    - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
+  - keystone_v3_smoke_focal_security:
+    - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
+tests_options:
+  overlay_ppas:
+    - ppa:ubuntu-security-proposed/ppa
+  tempest:
+    keystone_v3_smoke_security:
+      smoke: True
+    keystone_v3_smoke_focal_security:
+      smoke: True
+      include-list:
+        - "manila_tempest_tests.tests.api.admin.test_admin_actions.AdminActionsTest.*"
+        - "manila_tempest_tests.tests.api.admin.test_share_instances.ShareInstancesTest.*"
+        - "manila_tempest_tests.tests.api.admin.test_share_snapshot_instances.ShareSnapshotInstancesTest.*"
+        - "manila_tempest_tests.tests.api.admin.test_share_types.ShareTypesAdminTest.*"
+        - "manila_tempest_tests.tests.api.admin.test_shares_actions.SharesActionsAdminTest.*"
+      exclude-list:
+        # Exclude the known failures due to issues with octavia/manila policy
+        - "manila_tempest_tests.tests.api.admin.test_share_networks.ShareNetworkAdminTest"
+        - "manila_tempest_tests.tests.api.test_share_networks.ShareNetworksTest"
+        - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest"
+  force_deploy:
+    - lunar-antelope
+    - mantic-bobcat
+target_deploy_status:
+  ceilometer:
+    workload-status: blocked
+    workload-status-message-prefix: "Run the ceilometer-upgrade action on the leader to initialize ceilometer and gnocchi"
+  glance-simplestreams-sync:
+    workload-status: unknown
+    workload-status-message-prefix: ""
+  mongodb:
+    workload-status: unknown
+    workload-status-message-prefix: ""
+  neutron-api-plugin-ovn:
+    workload-status: waiting
+    workload-status-message-prefix: "'certificates' awaiting server certificate data, 'ovsdb-cms' incomplete"
+  octavia:
+    workload-status: blocked
+    workload-status-message-prefix: Awaiting
+  ovn-central:
+    workload-status: waiting
+    workload-status-message-prefix: "'ovsdb-peer' incomplete, 'certificates' awaiting server certificate data"
+  ovn-chassis:
+    workload-status: waiting
+    workload-status-message-prefix: "'certificates' awaiting server certificate data"
+  vault:
+    workload-status: blocked
+    workload-status-message-prefix: Vault needs to be initialized

--- a/tox.ini
+++ b/tox.ini
@@ -106,5 +106,12 @@ setenv = TEST_DEPLOY_TIMEOUT = 10000
 commands =
     functest-run-suite --keep-model --bundle {posargs}
 
+[testenv:security-distro-regression]
+basepython = python3
+changedir = tests/security-distro-regression
+setenv = TEST_DEPLOY_TIMEOUT = 10000
+commands =
+    functest-run-suite --keep-model --bundle {posargs}
+
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
We are deploying the same bundles here as are in the distro-regression directory, however in this case, the security proposed PPA will be enabled on all units. Notice that no cloud archive releases are included here because the security proposed ppa only needs testing from "distro".

These tests will be run weekly in zuul based on the osci.yaml updates.

These tests can also be run via tox, for example:
tox -e security-distro-regression jammy-yoga