### PR TITLE
Test with cloud:focal-ovn-22.03/proposed

### DIFF
--- a/tests/distro-regression/tests/bundles/focal-ussuri-ovn-22.03.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri-ovn-22.03.yaml
@@ -1,6 +1,7 @@
 variables:
   source: &source proposed
   openstack-origin: &openstack-origin distro-proposed
+  ovn-source: &ovn-source cloud:focal-ovn-22.03/proposed
 
 series: &series focal
 applications:
@@ -146,12 +147,15 @@ applications:
     num_units: 3
     options:
       source: *openstack-origin
+      ovn-source: *ovn-source
     channel: 22.03/edge
   neutron-api-plugin-ovn:
     charm: ch:neutron-api-plugin-ovn
     channel: ussuri/edge
   ovn-chassis:
     charm: ch:ovn-chassis
+    options:
+      ovn-source: *ovn-source
     channel: 22.03/edge
   neutron-api:
     charm: ch:neutron-api


### PR DESCRIPTION
The focal-ussuri-ovn-22.03 test was not running with the proposed pocket of cloud:focal-ovn-22.03/proposed. This has been updated in order to test changes that are in proposed.