### PR TITLE
Bump ceph-osd storage up to 15G

### DIFF
--- a/tests/distro-regression/tests/bundles/bionic-queens.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-queens.yaml
@@ -35,7 +35,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: luminous/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/bionic-rocky.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-rocky.yaml
@@ -43,7 +43,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: mimic/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/bionic-stein.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-stein.yaml
@@ -43,7 +43,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: octopus/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/bionic-train.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-train.yaml
@@ -43,7 +43,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: nautilus/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
@@ -43,7 +43,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: octopus/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-ussuri-base.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri-base.yaml
@@ -21,7 +21,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-ussuri-ovn-22.03.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri-ovn-22.03.yaml
@@ -49,7 +49,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: octopus/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -48,7 +48,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: octopus/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-victoria-base.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria-base.yaml
@@ -21,7 +21,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -49,7 +49,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: octopus/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-wallaby-base.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby-base.yaml
@@ -21,7 +21,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby.yaml
@@ -55,7 +55,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: pacific/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-xena-base.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena-base.yaml
@@ -21,7 +21,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-xena.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena.yaml
@@ -55,7 +55,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: pacific/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-yoga-base.yaml
+++ b/tests/distro-regression/tests/bundles/focal-yoga-base.yaml
@@ -21,7 +21,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/focal-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/focal-yoga.yaml
@@ -55,7 +55,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: quincy/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/jammy-antelope-base.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-antelope-base.yaml
@@ -21,7 +21,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/jammy-antelope.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-antelope.yaml
@@ -62,7 +62,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/jammy-bobcat.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-bobcat.yaml
@@ -62,7 +62,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/jammy-yoga-base.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga-base.yaml
@@ -21,7 +21,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/jammy-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga.yaml
@@ -54,7 +54,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: quincy/edge
   cinder:

--- a/tests/distro-regression/tests/bundles/jammy-zed-base.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed-base.yaml
@@ -21,7 +21,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/jammy-zed.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed.yaml
@@ -62,7 +62,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/lunar-antelope-base.yaml
+++ b/tests/distro-regression/tests/bundles/lunar-antelope-base.yaml
@@ -21,7 +21,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/lunar-antelope.yaml
+++ b/tests/distro-regression/tests/bundles/lunar-antelope.yaml
@@ -76,7 +76,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:

--- a/tests/distro-regression/tests/bundles/mantic-bobcat.yaml
+++ b/tests/distro-regression/tests/bundles/mantic-bobcat.yaml
@@ -76,7 +76,7 @@ applications:
     options:
       source: *source
     storage:
-      osd-devices: cinder,10G
+      osd-devices: cinder,15G
     constraints: mem=4096
     channel: *ceph-channel
   cinder:


### PR DESCRIPTION
The previous setting of 10G was full before zaza setup was able to compelete. This is likely a side-effect of recent change to zaza-openstack-tests to upload raw images instead of qcow2.

See LP: #2033915 for more details.