### PR TITLE
Use latest/edge for lunar bundles

### DIFF
--- a/tests/distro-regression/tests/bundles/lunar-antelope.yaml
+++ b/tests/distro-regression/tests/bundles/lunar-antelope.yaml
@@ -7,9 +7,9 @@ variables:
   # Set retrofit-series to focal to work-around the following bug:
   # https://bugs.launchpad.net/snap-octavia-diskimage-retrofit/+bug/1995130
   retrofit-series: &retrofit-series focal
-  openstack-channel: &openstack-channel 2023.1/edge
-  ceph-channel: &ceph-channel quincy/edge
-  ovn-channel: &ovn-channel 23.03/edge
+  openstack-channel: &openstack-channel latest/edge
+  ceph-channel: &ceph-channel latest/edge
+  ovn-channel: &ovn-channel latest/edge
   mysql-channel: &mysql-channel latest/edge
   rabbitmq-channel: &rabbitmq-channel latest/edge
   memcached-channel: &memcached-channel latest/edge


### PR DESCRIPTION
Lunar is really only used to verify SRUs so I think this makes more sense than backporting all of the build-on/run-on binary charm changes to stable/2023.1. This will get us by until it is end of life in January 2024.