### PR TITLE
Revive xenial-queens tests

### DIFF
--- a/osci.yaml
+++ b/osci.yaml
@@ -4,6 +4,7 @@
 - project:
     periodic-weekly:
       jobs:
+      - cot_distro-regression_xenial-queens
       - cot_distro-regression_bionic-queens
       - cot_distro-regression_bionic-ussuri
       - cot_distro-regression_focal-ussuri
@@ -29,6 +30,11 @@
     parent: func-target
     semaphore: distro-regression
     abstract: true
+- job:
+    name: cot_distro-regression_xenial-queens
+    parent: cot-func-target
+    vars:
+      tox_extra_args: '-- xenial-queens'
 - job:
     name: cot_distro-regression_bionic-queens
     parent: cot-func-target

--- a/tests/distro-regression/tests/bundles/xenial-queens.yaml
+++ b/tests/distro-regression/tests/bundles/xenial-queens.yaml
@@ -1,0 +1,304 @@
+variables:
+  source: &source cloud:xenial-queens/proposed
+  openstack-origin: &openstack-origin cloud:xenial-queens/proposed
+
+series: &series xenial
+applications:
+  aodh:
+    charm: ch:openstack-charmers-next-aodh
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  ceilometer:
+    charm: ch:openstack-charmers-next-ceilometer
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  ceilometer-agent:
+    charm: ch:openstack-charmers-next-ceilometer-agent
+  ceph-mon:
+    charm: ch:openstack-charmers-next-ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      source: *source
+    constraints: mem=1024
+  ceph-osd:
+    charm: ch:openstack-charmers-next-ceph-osd
+    num_units: 3
+    options:
+      source: *source
+    storage:
+      osd-devices: cinder,24G
+    constraints: mem=4096
+  cinder:
+    charm: ch:openstack-charmers-next-cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  cinder-ceph:
+    charm: ch:openstack-charmers-next-cinder-ceph
+  designate:
+    charm: ch:openstack-charmers-next-designate
+    num_units: 1
+    options:
+      nameservers: ns1.ubuntu.com.
+      neutron-domain: serverstack.ubuntu.com.
+      neutron-domain-email: bob@serverstack.ubuntu.com
+      nova-domain: serverstack.ubuntu.com.
+      nova-domain-email: bob@serverstack.ubuntu.com
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  designate-bind:
+    charm: ch:openstack-charmers-next-designate-bind
+    num_units: 1
+  glance:
+    charm: ch:openstack-charmers-next-glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  gnocchi:
+    charm: ch:openstack-charmers-next-gnocchi
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+  heat:
+    charm: ch:openstack-charmers-next-heat
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+  keystone:
+    charm: ch:openstack-charmers-next-keystone
+    num_units: 1
+    options:
+      admin-password: openstack
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  memcached:
+    charm: ch:memcached
+    num_units: 1
+    constraints: mem=1024
+  mysql:
+    charm: ch:openstack-charmers-next-percona-cluster
+    num_units: 1
+    options:
+      dataset-size: 50%
+      max-connections: 20000
+      root-password: ChangeMe123
+      source: *source
+      sst-password: ChangeMe123
+    constraints: mem=4096
+  neutron-api:
+    charm: ch:openstack-charmers-next-neutron-api
+    num_units: 1
+    options:
+      enable-ml2-port-security: true
+      enable-qos: true
+      enable-vlan-trunking: true
+      flat-network-providers: physnet1
+      neutron-security-groups: true
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  neutron-gateway:
+    charm: ch:openstack-charmers-next-neutron-gateway
+    num_units: 1
+    options:
+      bridge-mappings: physnet1:br-ex
+      instance-mtu: 1300
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+  neutron-openvswitch:
+    charm: ch:openstack-charmers-next-neutron-openvswitch
+  nova-cloud-controller:
+    charm: ch:openstack-charmers-next-nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+  nova-compute:
+    charm: ch:openstack-charmers-next-nova-compute
+    num_units: 3
+    options:
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    constraints: mem=4096
+  openstack-dashboard:
+    charm: ch:openstack-charmers-next-openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    constraints: mem=1024
+  rabbitmq-server:
+    charm: ch:openstack-charmers-next-rabbitmq-server
+    num_units: 1
+    options:
+      source: *source
+    constraints: mem=1024
+  swift-proxy:
+    charm: ch:openstack-charmers-next-swift-proxy
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      replicas: 3
+      swift-hash: fdfef9d4-8b06-11e2-8ac0-531c923c8fae
+      zone-assignment: manual
+    constraints: mem=1024
+  swift-storage-z1:
+    charm: ch:openstack-charmers-next-swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 1
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+  swift-storage-z2:
+    charm: ch:openstack-charmers-next-swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 2
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+  swift-storage-z3:
+    charm: ch:openstack-charmers-next-swift-storage
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      zone: 3
+    storage:
+      block-devices: cinder,10G
+    constraints: mem=1024
+relations:
+- - keystone:shared-db
+  - mysql:shared-db
+- - nova-cloud-controller:shared-db
+  - mysql:shared-db
+- - glance:shared-db
+  - mysql:shared-db
+- - cinder:shared-db
+  - mysql:shared-db
+- - heat:shared-db
+  - mysql:shared-db
+- - neutron-api:shared-db
+  - mysql:shared-db
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - nova-compute:cloud-compute
+  - nova-cloud-controller:cloud-compute
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-compute:ceph
+  - ceph-mon:client
+- - glance:identity-service
+  - keystone:identity-service
+- - glance:ceph
+  - ceph-mon:client
+- - glance:image-service
+  - cinder:image-service
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:storage-backend
+  - cinder-ceph:storage-backend
+- - cinder-ceph:ceph
+  - ceph-mon:client
+- - neutron-gateway:quantum-network-service
+  - nova-cloud-controller:quantum-network-service
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - ceilometer:identity-service
+  - keystone:identity-service
+- - ceilometer:amqp
+  - rabbitmq-server:amqp
+- - ceilometer-agent:nova-ceilometer
+  - nova-compute:nova-ceilometer
+- - ceilometer-agent:ceilometer-service
+  - ceilometer:ceilometer-service
+- - ceilometer-agent:amqp
+  - rabbitmq-server:amqp
+- - heat:identity-service
+  - keystone:identity-service
+- - heat:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-api:neutron-api
+  - nova-cloud-controller:neutron-api
+- - neutron-api:neutron-plugin-api
+  - neutron-openvswitch:neutron-plugin-api
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-api:neutron-plugin-api
+  - neutron-gateway:neutron-plugin-api
+- - neutron-openvswitch:neutron-plugin
+  - nova-compute:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - aodh:shared-db
+  - mysql:shared-db
+- - designate:shared-db
+  - mysql:shared-db
+- - aodh:amqp
+  - rabbitmq-server:amqp
+- - aodh:identity-service
+  - keystone:identity-service
+- - designate:identity-service
+  - keystone:identity-service
+- - designate:amqp
+  - rabbitmq-server:amqp
+- - designate:dns-backend
+  - designate-bind:dns-backend
+- - designate:coordinator-memcached
+  - memcached:cache
+- - gnocchi:shared-db
+  - mysql:shared-db
+- - gnocchi:storage-ceph
+  - ceph-mon:client
+- - gnocchi:amqp
+  - rabbitmq-server:amqp
+- - gnocchi:coordinator-memcached
+  - memcached:cache
+- - gnocchi:metric-service
+  - ceilometer:metric-service
+- - gnocchi:identity-service
+  - keystone:identity-service
+- - cinder-ceph:ceph-access
+  - nova-compute:ceph-access
+- - ceilometer:identity-credentials
+  - keystone:identity-credentials
+- - designate:dnsaas
+  - neutron-api:external-dns

--- a/tests/distro-regression/tests/tests.yaml
+++ b/tests/distro-regression/tests/tests.yaml
@@ -1,5 +1,6 @@
 smoke_bundles:
-  - bionic_queens: bionic-queens
+  - xenial_queens: xenial-queens
+  - xenial_queens: bionic-queens
   - bionic_ussuri: bionic-ussuri
   - focal_ussuri: focal-ussuri
   - focal_ussuri: focal-ussuri-ovn-22.03
@@ -21,7 +22,7 @@ smoke_bundles:
   - focal_upgrades: focal-ussuri-to-yoga-upgrades
   - jammy_upgrades: jammy-yoga-to-caracal-upgrades
 configure:
-  - bionic_queens: &bionic_queens
+  - xenial_queens: &xenial_queens
     - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
     - zaza.openstack.charm_tests.glance.setup.add_lts_image
     - zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
@@ -31,7 +32,7 @@ configure:
     - zaza.openstack.charm_tests.keystone.setup.add_tempest_roles
     - zaza.openstack.charm_tests.glance.setup.add_cirros_image
     - zaza.openstack.charm_tests.glance.setup.add_cirros_alt_image
-  - bionic_queens_security: *bionic_queens
+  - bionic_queens_security: *xenial_queens
   - bionic_ussuri:
     - zaza.openstack.charm_tests.ceilometer.setup.basic_setup
     - zaza.openstack.charm_tests.glance_simplestreams_sync.setup.sync_images
@@ -70,7 +71,7 @@ configure:
   - focal_wallaby: *focal_ussuri
   - jammy_upgrades: *focal_ussuri
 tests:
-  - bionic_queens:
+  - xenial_queens:
     - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
   - bionic_queens_security:
     - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
@@ -119,7 +120,7 @@ tests_options:
     overlay_ppas:
       - ppa:ubuntu-security-proposed/ppa
   tempest:
-    bionic_queens:
+    xenial_queens:
       smoke: True
       serial: True
       exclude-list:
@@ -312,6 +313,7 @@ tests_options:
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         - "watcher_tempest_plugin.*"
   force_deploy:
+    - xenial-queens
     - bionic-queens
     - bionic-ussuri
     - lunar-antelope

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands =
 [testenv:func-target]
 basepython = python3
 changedir = tests/distro-regression
+setenv = OS_TEST_TIMEOUT=1200
 commands =
     functest-run-suite --keep-model --bundle {posargs}
 


### PR DESCRIPTION
The xenial-queens tests are still needed for ESM regression testing.

This also sets OS_TEST_TIMEOUT=1200 for the tox func-target to help reduce test timeouts.