### PR TITLE
Add octavia tests

### DIFF
--- a/tests/distro-regression/tests/tests.yaml
+++ b/tests/distro-regression/tests/tests.yaml
@@ -150,8 +150,6 @@ tests_options:
         - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
         # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
         - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
-        # octavia test fails with self.creds_client.assign_user_role 'No "load-balancer_admin" role found'
-        - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest"
     bionic_queens_security:
       smoke: True
       serial: True
@@ -174,14 +172,13 @@ tests_options:
         - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
         # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
         - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
-        # octavia test fails with self.creds_client.assign_user_role 'No "load-balancer_admin" role found'
-        - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest"
     bionic_ussuri:
       smoke: True
       serial: True
       include-list:
         - "heat_tempest_plugin.tests.api.*"
         - "heat_tempest_plugin.tests.functional.*"
+        - "octavia_tempest_plugin.tests.scenario.*"
       exclude-list:
         # designate tests fail with self.creds_client.assign_user_role_on_system 'No "reader" role found'
         - "designate_tempest_plugin.tests.api.v2.test_zones_exports.ZonesExportTest"
@@ -198,8 +195,8 @@ tests_options:
         - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
         # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
         - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
-        # octavia test fails with self.creds_client.assign_user_role 'No "load-balancer_admin" role found'
-        - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest"
+        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
+        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
     focal_ussuri:
       smoke: True
       serial: True
@@ -215,6 +212,7 @@ tests_options:
         - "magnum_tempest_plugin.tests.api.v1.test_cluster_template"
         - "magnum_tempest_plugin.tests.api.v1.test_cluster_template_admin"
         - "magnum_tempest_plugin.tests.api.v1.test_magnum_service"
+        - "octavia_tempest_plugin.tests.scenario.*"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         # - "watcher_tempest_plugin.tests.api"
         # - "watcher_tempest_plugin.tests.scenario.test_execute_host_maintenance"
@@ -246,7 +244,8 @@ tests_options:
         # The test expects a 400 error while the server returns a 401 error due to glance
         # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
         - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
-        - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest"
+        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
+        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         - "watcher_tempest_plugin.*"
     focal_ussuri_security:
@@ -264,6 +263,7 @@ tests_options:
         - "magnum_tempest_plugin.tests.api.v1.test_cluster_template"
         - "magnum_tempest_plugin.tests.api.v1.test_cluster_template_admin"
         - "magnum_tempest_plugin.tests.api.v1.test_magnum_service"
+        - "octavia_tempest_plugin.tests.scenario.*"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         # - "watcher_tempest_plugin.tests.api"
         # - "watcher_tempest_plugin.tests.scenario.test_execute_host_maintenance"
@@ -295,7 +295,8 @@ tests_options:
         # The test expects a 400 error while the server returns a 401 error due to glance
         # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
         - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
-        - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest"
+        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
+        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         - "watcher_tempest_plugin.*"
     focal_upgrades:
@@ -313,6 +314,7 @@ tests_options:
         - "magnum_tempest_plugin.tests.api.v1.test_cluster_template"
         - "magnum_tempest_plugin.tests.api.v1.test_cluster_template_admin"
         - "magnum_tempest_plugin.tests.api.v1.test_magnum_service"
+        - "octavia_tempest_plugin.tests.scenario.*"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         # - "watcher_tempest_plugin.tests.api"
         # - "watcher_tempest_plugin.tests.scenario.test_execute_host_maintenance"
@@ -344,7 +346,8 @@ tests_options:
         # The test expects a 400 error while the server returns a 401 error due to glance
         # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
         - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
-        - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest"
+        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
+        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         - "watcher_tempest_plugin.*"
     focal_wallaby:
@@ -362,6 +365,7 @@ tests_options:
         - "magnum_tempest_plugin.tests.api.v1.test_cluster_template"
         - "magnum_tempest_plugin.tests.api.v1.test_cluster_template_admin"
         - "magnum_tempest_plugin.tests.api.v1.test_magnum_service"
+        - "octavia_tempest_plugin.tests.scenario.*"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         # - "watcher_tempest_plugin.tests.api"
         # - "watcher_tempest_plugin.tests.scenario.test_execute_host_maintenance"
@@ -390,7 +394,8 @@ tests_options:
         # The test expects a 400 error while the server returns a 401 error due to glance
         # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
         - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
-        - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest"
+        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
+        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         - "watcher_tempest_plugin.*"
     jammy_upgrades:
@@ -408,6 +413,7 @@ tests_options:
         - "magnum_tempest_plugin.tests.api.v1.test_cluster_template"
         - "magnum_tempest_plugin.tests.api.v1.test_cluster_template_admin"
         - "magnum_tempest_plugin.tests.api.v1.test_magnum_service"
+        - "octavia_tempest_plugin.tests.scenario.*"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         # - "watcher_tempest_plugin.tests.api"
         # - "watcher_tempest_plugin.tests.scenario.test_execute_host_maintenance"
@@ -436,7 +442,8 @@ tests_options:
         # The test expects a 400 error while the server returns a 401 error due to glance
         # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
         - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
-        - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest"
+        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
+        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         - "watcher_tempest_plugin.*"
   force_deploy:

--- a/tests/distro-regression/tests/tests.yaml
+++ b/tests/distro-regression/tests/tests.yaml
@@ -71,24 +71,14 @@ configure:
   - focal_wallaby: *focal_ussuri
   - jammy_upgrades: *focal_ussuri
 tests:
-  - xenial_queens:
+  - xenial_queens: &xenial_queens_tests
     - zaza.openstack.charm_tests.status.tests.ProposedPackageReport
     - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
-  - bionic_queens_security:
-    - zaza.openstack.charm_tests.status.tests.ProposedPackageReport
-    - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
-  - bionic_ussuri:
-    - zaza.openstack.charm_tests.status.tests.ProposedPackageReport
-    - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
-  - focal_ussuri:
-    - zaza.openstack.charm_tests.status.tests.ProposedPackageReport
-    - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
-  - focal_ussuri_security:
-    - zaza.openstack.charm_tests.status.tests.ProposedPackageReport
-    - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
-  - focal_wallaby:
-    - zaza.openstack.charm_tests.status.tests.ProposedPackageReport
-    - zaza.openstack.charm_tests.tempest.tests.TempestTestWithKeystoneV3
+  - bionic_queens_security: *xenial_queens_tests
+  - bionic_ussuri: *xenial_queens_tests
+  - focal_ussuri: *xenial_queens_tests
+  - focal_ussuri_security: *xenial_queens_tests
+  - focal_wallaby: *xenial_queens_tests
   - focal_upgrades:
     # ussuri->victoria
     - zaza.openstack.charm_tests.charm_upgrade.tests.FullCloudCharmUpgradeTest
@@ -131,10 +121,10 @@ tests_options:
     xenial_queens:
       smoke: True
       serial: True
-      include-list:
+      include-list: &xenial_queens_include_list
         - "heat_tempest_plugin.tests.api.*"
         - "heat_tempest_plugin.tests.functional.*"
-      exclude-list:
+      exclude-list: &exclude_list
         # designate tests fail with self.creds_client.assign_user_role_on_system 'No "reader" role found'
         - "designate_tempest_plugin.tests.api.v2.test_zones_exports.ZonesExportTest"
         - "designate_tempest_plugin.tests.api.v2.test_zones_imports.ZonesImportTest"
@@ -150,28 +140,26 @@ tests_options:
         - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
         # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
         - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
+        # Exclude the known failures due to issues with octavia/manila policy
+        - "manila_tempest_tests.tests.api.admin.test_share_networks.ShareNetworkAdminTest"
+        - "manila_tempest_tests.tests.api.test_share_networks.ShareNetworksTest"
+        # Implemented on container-infra 1.10 which is available in >=Xena
+        # https://opendev.org/openstack/magnum/commit/0e6d17893
+        # https://opendev.org/openstack/magnum-tempest-plugin/commit/b68a678f37de0a769e7ee8dbefa9bdfe6cf445cc
+        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_list_sign_delete_clusters"
+        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_zero_nodes"
+        # The test expects a 400 error while the server returns a 401 error due to glance
+        # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
+        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
+        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
+        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
+        # Note(coreycb): Disable watcher tests until all the failures can be debugged.
+        - "watcher_tempest_plugin.*"
     bionic_queens_security:
       smoke: True
       serial: True
-      include-list:
-        - "heat_tempest_plugin.tests.api.*"
-        - "heat_tempest_plugin.tests.functional.*"
-      exclude-list:
-        # designate tests fail with self.creds_client.assign_user_role_on_system 'No "reader" role found'
-        - "designate_tempest_plugin.tests.api.v2.test_zones_exports.ZonesExportTest"
-        - "designate_tempest_plugin.tests.api.v2.test_zones_imports.ZonesImportTest"
-        # HTTP 401 unauthorized
-        - "heat_tempest_plugin.tests.functional.test_create_update_neutron_port.UpdatePortTest.test_update_with_mac_address"
-        - "heat_tempest_plugin.tests.functional.test_encryption_vol_type.EncryptionVolTypeTest.test_create_update"
-        # Need fixed demo network defined (ie. fixed_network_name=demo_project_network)
-        - "heat_tempest_plugin.tests.functional.test_encrypted_parameter.EncryptedParametersTest.test_db_encryption"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_add_delete_poolmember"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_create_update_loadbalancer"
-        - "heat_tempest_plugin.tests.functional.test_os_wait_condition.OSWaitCondition.test_create_stack_with_multi_signal_waitcondition"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_metadata"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
-        # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
-        - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
+      include-list: *xenial_queens_include_list
+      exclude-list: *exclude_list
     bionic_ussuri:
       smoke: True
       serial: True
@@ -179,28 +167,11 @@ tests_options:
         - "heat_tempest_plugin.tests.api.*"
         - "heat_tempest_plugin.tests.functional.*"
         - "octavia_tempest_plugin.tests.scenario.*"
-      exclude-list:
-        # designate tests fail with self.creds_client.assign_user_role_on_system 'No "reader" role found'
-        - "designate_tempest_plugin.tests.api.v2.test_zones_exports.ZonesExportTest"
-        - "designate_tempest_plugin.tests.api.v2.test_zones_imports.ZonesImportTest"
-        # HTTP 401 unauthorized
-        - "heat_tempest_plugin.tests.functional.test_create_update_neutron_port.UpdatePortTest.test_update_with_mac_address"
-        - "heat_tempest_plugin.tests.functional.test_encryption_vol_type.EncryptionVolTypeTest.test_create_update"
-        # Need fixed demo network defined (ie. fixed_network_name=demo_project_network)
-        - "heat_tempest_plugin.tests.functional.test_encrypted_parameter.EncryptedParametersTest.test_db_encryption"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_add_delete_poolmember"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_create_update_loadbalancer"
-        - "heat_tempest_plugin.tests.functional.test_os_wait_condition.OSWaitCondition.test_create_stack_with_multi_signal_waitcondition"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_metadata"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
-        # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
-        - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
-        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
-        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
+      exclude-list: *exclude_list
     focal_ussuri:
       smoke: True
       serial: True
-      include-list:
+      include-list: &focal_ussuri_include_list
         - "heat_tempest_plugin.tests.api.*"
         - "heat_tempest_plugin.tests.functional.*"
         - "manila_tempest_tests.tests.api.admin.test_admin_actions.AdminActionsTest.*"
@@ -217,235 +188,27 @@ tests_options:
         # - "watcher_tempest_plugin.tests.api"
         # - "watcher_tempest_plugin.tests.scenario.test_execute_host_maintenance"
         # - "watcher_tempest_plugin.tests.scenario.test_execute_vm_workload_consolidation"
-      exclude-list:
-        # designate failures due to check_list_show_RBAC_enforcement returning "Unauthorized"
-        - "designate_tempest_plugin.tests.api.v2.test_zones_exports.ZonesExportTest.test_show_zone_export"
-        - "designate_tempest_plugin.tests.api.v2.test_zones_imports.ZonesImportTest.test_show_zone_import"
-        # HTTP 401 unauthorized
-        - "heat_tempest_plugin.tests.functional.test_create_update_neutron_port.UpdatePortTest.test_update_with_mac_address"
-        - "heat_tempest_plugin.tests.functional.test_encryption_vol_type.EncryptionVolTypeTest.test_create_update"
-        # Need fixed demo network defined (ie. fixed_network_name=demo_project_network)
-        - "heat_tempest_plugin.tests.functional.test_encrypted_parameter.EncryptedParametersTest.test_db_encryption"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_add_delete_poolmember"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_create_update_loadbalancer"
-        - "heat_tempest_plugin.tests.functional.test_os_wait_condition.OSWaitCondition.test_create_stack_with_multi_signal_waitcondition"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_metadata"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
-        # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
-        - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
-        # Exclude the known failures due to issues with octavia/manila policy
-        - "manila_tempest_tests.tests.api.admin.test_share_networks.ShareNetworkAdminTest"
-        - "manila_tempest_tests.tests.api.test_share_networks.ShareNetworksTest"
-        # Implemented on container-infra 1.10 which is available in >=Xena
-        # https://opendev.org/openstack/magnum/commit/0e6d17893
-        # https://opendev.org/openstack/magnum-tempest-plugin/commit/b68a678f37de0a769e7ee8dbefa9bdfe6cf445cc
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_list_sign_delete_clusters"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_zero_nodes"
-        # The test expects a 400 error while the server returns a 401 error due to glance
-        # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
-        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
-        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
-        # Note(coreycb): Disable watcher tests until all the failures can be debugged.
-        - "watcher_tempest_plugin.*"
+      exclude-list: *exclude_list
     focal_ussuri_security:
       smoke: True
       serial: True
-      include-list:
-        - "heat_tempest_plugin.tests.api.*"
-        - "heat_tempest_plugin.tests.functional.*"
-        - "manila_tempest_tests.tests.api.admin.test_admin_actions.AdminActionsTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_instances.ShareInstancesTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_snapshot_instances.ShareSnapshotInstancesTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_types.ShareTypesAdminTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_shares_actions.SharesActionsAdminTest.*"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster_template"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster_template_admin"
-        - "magnum_tempest_plugin.tests.api.v1.test_magnum_service"
-        - "octavia_tempest_plugin.tests.scenario.*"
-        # Note(coreycb): Disable watcher tests until all the failures can be debugged.
-        # - "watcher_tempest_plugin.tests.api"
-        # - "watcher_tempest_plugin.tests.scenario.test_execute_host_maintenance"
-        # - "watcher_tempest_plugin.tests.scenario.test_execute_vm_workload_consolidation"
-      exclude-list:
-        # designate failures due to check_list_show_RBAC_enforcement returning "Unauthorized"
-        - "designate_tempest_plugin.tests.api.v2.test_zones_exports.ZonesExportTest.test_show_zone_export"
-        - "designate_tempest_plugin.tests.api.v2.test_zones_imports.ZonesImportTest.test_show_zone_import"
-        # HTTP 401 unauthorized
-        - "heat_tempest_plugin.tests.functional.test_create_update_neutron_port.UpdatePortTest.test_update_with_mac_address"
-        - "heat_tempest_plugin.tests.functional.test_encryption_vol_type.EncryptionVolTypeTest.test_create_update"
-        # Need fixed demo network defined (ie. fixed_network_name=demo_project_network)
-        - "heat_tempest_plugin.tests.functional.test_encrypted_parameter.EncryptedParametersTest.test_db_encryption"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_add_delete_poolmember"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_create_update_loadbalancer"
-        - "heat_tempest_plugin.tests.functional.test_os_wait_condition.OSWaitCondition.test_create_stack_with_multi_signal_waitcondition"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_metadata"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
-        # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
-        - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
-        # Exclude the known failures due to issues with octavia/manila policy
-        - "manila_tempest_tests.tests.api.admin.test_share_networks.ShareNetworkAdminTest"
-        - "manila_tempest_tests.tests.api.test_share_networks.ShareNetworksTest"
-        # Implemented on container-infra 1.10 which is available in >=Xena
-        # https://opendev.org/openstack/magnum/commit/0e6d17893
-        # https://opendev.org/openstack/magnum-tempest-plugin/commit/b68a678f37de0a769e7ee8dbefa9bdfe6cf445cc
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_list_sign_delete_clusters"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_zero_nodes"
-        # The test expects a 400 error while the server returns a 401 error due to glance
-        # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
-        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
-        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
-        # Note(coreycb): Disable watcher tests until all the failures can be debugged.
-        - "watcher_tempest_plugin.*"
+      include-list: *focal_ussuri_include_list
+      exclude-list: *exclude_list
     focal_upgrades:
       smoke: True
       serial: True
-      include-list:
-        - "heat_tempest_plugin.tests.api.*"
-        - "heat_tempest_plugin.tests.functional.*"
-        - "manila_tempest_tests.tests.api.admin.test_admin_actions.AdminActionsTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_instances.ShareInstancesTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_snapshot_instances.ShareSnapshotInstancesTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_types.ShareTypesAdminTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_shares_actions.SharesActionsAdminTest.*"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster_template"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster_template_admin"
-        - "magnum_tempest_plugin.tests.api.v1.test_magnum_service"
-        - "octavia_tempest_plugin.tests.scenario.*"
-        # Note(coreycb): Disable watcher tests until all the failures can be debugged.
-        # - "watcher_tempest_plugin.tests.api"
-        # - "watcher_tempest_plugin.tests.scenario.test_execute_host_maintenance"
-        # - "watcher_tempest_plugin.tests.scenario.test_execute_vm_workload_consolidation"
-      exclude-list:
-        # designate failures due to check_list_show_RBAC_enforcement returning "Unauthorized"
-        - "designate_tempest_plugin.tests.api.v2.test_zones_exports.ZonesExportTest.test_show_zone_export"
-        - "designate_tempest_plugin.tests.api.v2.test_zones_imports.ZonesImportTest.test_show_zone_import"
-        # HTTP 401 unauthorized
-        - "heat_tempest_plugin.tests.functional.test_create_update_neutron_port.UpdatePortTest.test_update_with_mac_address"
-        - "heat_tempest_plugin.tests.functional.test_encryption_vol_type.EncryptionVolTypeTest.test_create_update"
-        # Need fixed demo network defined (ie. fixed_network_name=demo_project_network)
-        - "heat_tempest_plugin.tests.functional.test_encrypted_parameter.EncryptedParametersTest.test_db_encryption"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_add_delete_poolmember"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_create_update_loadbalancer"
-        - "heat_tempest_plugin.tests.functional.test_os_wait_condition.OSWaitCondition.test_create_stack_with_multi_signal_waitcondition"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_metadata"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
-        # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
-        - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
-        # Exclude the known failures due to issues with octavia/manila policy
-        - "manila_tempest_tests.tests.api.admin.test_share_networks.ShareNetworkAdminTest"
-        - "manila_tempest_tests.tests.api.test_share_networks.ShareNetworksTest"
-        # Implemented on container-infra 1.10 which is available in >=Xena
-        # https://opendev.org/openstack/magnum/commit/0e6d17893
-        # https://opendev.org/openstack/magnum-tempest-plugin/commit/b68a678f37de0a769e7ee8dbefa9bdfe6cf445cc
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_list_sign_delete_clusters"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_zero_nodes"
-        # The test expects a 400 error while the server returns a 401 error due to glance
-        # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
-        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
-        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
-        # Note(coreycb): Disable watcher tests until all the failures can be debugged.
-        - "watcher_tempest_plugin.*"
+      include-list: *focal_ussuri_include_list
+      exclude-list: *exclude_list
     focal_wallaby:
       smoke: True
       serial: True
-      include-list:
-        - "heat_tempest_plugin.tests.api.*"
-        - "heat_tempest_plugin.tests.functional.*"
-        - "manila_tempest_tests.tests.api.admin.test_admin_actions.AdminActionsTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_instances.ShareInstancesTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_snapshot_instances.ShareSnapshotInstancesTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_types.ShareTypesAdminTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_shares_actions.SharesActionsAdminTest.*"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster_template"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster_template_admin"
-        - "magnum_tempest_plugin.tests.api.v1.test_magnum_service"
-        - "octavia_tempest_plugin.tests.scenario.*"
-        # Note(coreycb): Disable watcher tests until all the failures can be debugged.
-        # - "watcher_tempest_plugin.tests.api"
-        # - "watcher_tempest_plugin.tests.scenario.test_execute_host_maintenance"
-        # - "watcher_tempest_plugin.tests.scenario.test_execute_vm_workload_consolidation"
-      exclude-list:
-        # HTTP 401 unauthorized
-        - "heat_tempest_plugin.tests.functional.test_create_update_neutron_port.UpdatePortTest.test_update_with_mac_address"
-        - "heat_tempest_plugin.tests.functional.test_encryption_vol_type.EncryptionVolTypeTest.test_create_update"
-        # Need fixed demo network defined (ie. fixed_network_name=demo_project_network)
-        - "heat_tempest_plugin.tests.functional.test_encrypted_parameter.EncryptedParametersTest.test_db_encryption"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_add_delete_poolmember"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_create_update_loadbalancer"
-        - "heat_tempest_plugin.tests.functional.test_os_wait_condition.OSWaitCondition.test_create_stack_with_multi_signal_waitcondition"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_metadata"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
-        # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
-        - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
-        # Exclude the known failures due to issues with octavia/manila policy
-        - "manila_tempest_tests.tests.api.admin.test_share_networks.ShareNetworkAdminTest"
-        - "manila_tempest_tests.tests.api.test_share_networks.ShareNetworksTest"
-        # Implemented on container-infra 1.10 which is available in >=Xena
-        # https://opendev.org/openstack/magnum/commit/0e6d17893
-        # https://opendev.org/openstack/magnum-tempest-plugin/commit/b68a678f37de0a769e7ee8dbefa9bdfe6cf445cc
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_list_sign_delete_clusters"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_zero_nodes"
-        # The test expects a 400 error while the server returns a 401 error due to glance
-        # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
-        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
-        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
-        # Note(coreycb): Disable watcher tests until all the failures can be debugged.
-        - "watcher_tempest_plugin.*"
+      include-list: *focal_ussuri_include_list
+      exclude-list: *exclude_list
     jammy_upgrades:
       smoke: True
       serial: True
-      include-list:
-        - "heat_tempest_plugin.tests.api.*"
-        - "heat_tempest_plugin.tests.functional.*"
-        - "manila_tempest_tests.tests.api.admin.test_admin_actions.AdminActionsTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_instances.ShareInstancesTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_snapshot_instances.ShareSnapshotInstancesTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_share_types.ShareTypesAdminTest.*"
-        - "manila_tempest_tests.tests.api.admin.test_shares_actions.SharesActionsAdminTest.*"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster_template"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster_template_admin"
-        - "magnum_tempest_plugin.tests.api.v1.test_magnum_service"
-        - "octavia_tempest_plugin.tests.scenario.*"
-        # Note(coreycb): Disable watcher tests until all the failures can be debugged.
-        # - "watcher_tempest_plugin.tests.api"
-        # - "watcher_tempest_plugin.tests.scenario.test_execute_host_maintenance"
-        # - "watcher_tempest_plugin.tests.scenario.test_execute_vm_workload_consolidation"
-      exclude-list:
-        # HTTP 401 unauthorized
-        - "heat_tempest_plugin.tests.functional.test_create_update_neutron_port.UpdatePortTest.test_update_with_mac_address"
-        - "heat_tempest_plugin.tests.functional.test_encryption_vol_type.EncryptionVolTypeTest.test_create_update"
-        # Need fixed demo network defined (ie. fixed_network_name=demo_project_network)
-        - "heat_tempest_plugin.tests.functional.test_encrypted_parameter.EncryptedParametersTest.test_db_encryption"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_add_delete_poolmember"
-        - "heat_tempest_plugin.tests.functional.test_lbaasv2.LoadBalancerv2Test.test_create_update_loadbalancer"
-        - "heat_tempest_plugin.tests.functional.test_os_wait_condition.OSWaitCondition.test_create_stack_with_multi_signal_waitcondition"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_metadata"
-        - "heat_tempest_plugin.tests.functional.test_software_config.ParallelDeploymentsTest.test_deployments_timeout_failed"
-        # testtools.matchers._impl.MismatchError: 'CREATE_FAILED' not in ['CREATE_IN_PROGRESS', 'CREATE_COMPLETE']
-        - "heat_tempest_plugin.tests.functional.test_stack_events.StackEventsTest.test_event"
-        # Exclude the known failures due to issues with octavia/manila policy
-        - "manila_tempest_tests.tests.api.admin.test_share_networks.ShareNetworkAdminTest"
-        - "manila_tempest_tests.tests.api.test_share_networks.ShareNetworksTest"
-        # Implemented on container-infra 1.10 which is available in >=Xena
-        # https://opendev.org/openstack/magnum/commit/0e6d17893
-        # https://opendev.org/openstack/magnum-tempest-plugin/commit/b68a678f37de0a769e7ee8dbefa9bdfe6cf445cc
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_list_sign_delete_clusters"
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_zero_nodes"
-        # The test expects a 400 error while the server returns a 401 error due to glance
-        # See logs at https://pastebin.ubuntu.com/p/V3DMcVmtyF/
-        - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
-        # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
-        - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
-        # Note(coreycb): Disable watcher tests until all the failures can be debugged.
-        - "watcher_tempest_plugin.*"
+      include-list: *focal_ussuri_include_list
+      exclude-list: *exclude_list
   force_deploy:
     - xenial-queens
     - bionic-queens


### PR DESCRIPTION
Depends-On: https://github.com/openstack-charmers/zaza-openstack-tests/pull/1167

This change also simplifies tests.yaml with yaml reference anchors/aliases. The test sections are updated to de-duplicate much of the testing config. This reduces tests.yaml to having a single shared exclude-list and reduces the duplication among include-lists.