### PR TITLE
Various fixes for distro tests

### DIFF
--- a/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/bionic-ussuri.yaml
@@ -237,6 +237,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: ussuri/edge
   glance-simplestreams-sync:
     charm: ch:glance-simplestreams-sync

--- a/tests/distro-regression/tests/bundles/focal-ussuri-ovn-22.03.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri-ovn-22.03.yaml
@@ -264,6 +264,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: ussuri/edge
   octavia-mysql-router:
     charm: ch:mysql-router

--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -279,6 +279,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router
@@ -295,6 +296,7 @@ applications:
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-series: *series
+    constraints: mem=4096
     channel: *openstack-channel
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/focal-ussuri.yaml
+++ b/tests/distro-regression/tests/bundles/focal-ussuri.yaml
@@ -296,7 +296,6 @@ applications:
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-series: *series
-    constraints: mem=4096
     channel: *openstack-channel
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/focal-victoria.yaml
+++ b/tests/distro-regression/tests/bundles/focal-victoria.yaml
@@ -280,6 +280,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router

--- a/tests/distro-regression/tests/bundles/focal-wallaby.yaml
+++ b/tests/distro-regression/tests/bundles/focal-wallaby.yaml
@@ -306,6 +306,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router

--- a/tests/distro-regression/tests/bundles/focal-xena.yaml
+++ b/tests/distro-regression/tests/bundles/focal-xena.yaml
@@ -306,6 +306,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router

--- a/tests/distro-regression/tests/bundles/focal-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/focal-yoga.yaml
@@ -306,6 +306,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router

--- a/tests/distro-regression/tests/bundles/jammy-antelope.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-antelope.yaml
@@ -323,6 +323,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router
@@ -586,6 +587,8 @@ relations:
   - watcher-mysql-router:shared-db
 - - watcher-mysql-router:db-router
   - mysql-innodb-cluster:db-router
+- - watcher:certificates
+  - vault:certificates
 - - keystone:identity-service
   - watcher:identity-service
 - - rabbitmq-server:amqp

--- a/tests/distro-regression/tests/bundles/jammy-bobcat.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-bobcat.yaml
@@ -2,13 +2,13 @@ variables:
   source: &source cloud:jammy-bobcat/proposed
   openstack-origin: &openstack-origin cloud:jammy-bobcat/proposed
   retrofit-uca-pocket: &retrofit-uca-pocket bobcat
-  openstack-channel: &openstack-channel latest/edge
-  ceph-channel: &ceph-channel latest/edge
-  ovn-channel: &ovn-channel latest/edge
-  mysql-channel: &mysql-channel latest/edge
-  rabbitmq-channel: &rabbitmq-channel latest/edge
+  openstack-channel: &openstack-channel 2023.2/edge
+  ceph-channel: &ceph-channel reef/edge
+  ovn-channel: &ovn-channel 23.09/edge
+  mysql-channel: &mysql-channel 8.0/edge
+  rabbitmq-channel: &rabbitmq-channel 3.9/edge
   memcached-channel: &memcached-channel latest/edge
-  vault-channel: &vault-channel latest/edge
+  vault-channel: &vault-channel 1.8/edge
 
 series: &series jammy
 applications:
@@ -320,6 +320,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router
@@ -583,6 +584,8 @@ relations:
   - watcher-mysql-router:shared-db
 - - watcher-mysql-router:db-router
   - mysql-innodb-cluster:db-router
+- - watcher:certificates
+  - vault:certificates
 - - keystone:identity-service
   - watcher:identity-service
 - - rabbitmq-server:amqp

--- a/tests/distro-regression/tests/bundles/jammy-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga.yaml
@@ -305,6 +305,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router
@@ -321,6 +322,7 @@ applications:
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-series: *series
+    constraints: mem=4096
     channel: *openstack-channel
 relations:
 - - nova-cloud-controller:amqp

--- a/tests/distro-regression/tests/bundles/jammy-zed.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-zed.yaml
@@ -304,6 +304,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router

--- a/tests/distro-regression/tests/bundles/lunar-antelope.yaml
+++ b/tests/distro-regression/tests/bundles/lunar-antelope.yaml
@@ -340,6 +340,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router
@@ -602,6 +603,8 @@ relations:
   - watcher-mysql-router:shared-db
 - - watcher-mysql-router:db-router
   - mysql-innodb-cluster:db-router
+- - watcher:certificates
+  - vault:certificates
 - - keystone:identity-service
   - watcher:identity-service
 - - rabbitmq-server:amqp

--- a/tests/distro-regression/tests/bundles/mantic-bobcat.yaml
+++ b/tests/distro-regression/tests/bundles/mantic-bobcat.yaml
@@ -1,7 +1,7 @@
 variables:
   source: &source proposed
   openstack-origin: &openstack-origin distro-proposed
-  # Set retrofit-series to jammy because kinetic images aren't
+  # Set retrofit-series to jammy because mantic images aren't
   # available by default.
   retrofit-series: &retrofit-series jammy
   openstack-channel: &openstack-channel latest/edge
@@ -325,6 +325,7 @@ applications:
       openstack-origin: *openstack-origin
       spare-pool-size: 2
       loadbalancer-topology: 'ACTIVE_STANDBY'
+    constraints: mem=4096
     channel: *openstack-channel
   octavia-mysql-router:
     charm: ch:mysql-router
@@ -587,6 +588,8 @@ relations:
   - watcher-mysql-router:shared-db
 - - watcher-mysql-router:db-router
   - mysql-innodb-cluster:db-router
+- - watcher:certificates
+  - vault:certificates
 - - keystone:identity-service
   - watcher:identity-service
 - - rabbitmq-server:amqp

--- a/tests/distro-regression/tests/tests.yaml
+++ b/tests/distro-regression/tests/tests.yaml
@@ -153,6 +153,8 @@ tests_options:
         - "magnum_tempest_plugin.tests.api.v1.test_cluster.ClusterTest.test_create_cluster_with_nonexisting_flavor"
         # "Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING
         - "octavia_tempest_plugin.tests.scenario.v2.test_load_balancer.LoadBalancerScenarioTest"
+        # 503 is not the expected code 200: https://bugs.launchpad.net/snap-octavia-diskimage-retrofit/+bug/2027585
+        - "octavia_tempest_plugin.tests.scenario.v2.test_traffic_ops.TrafficOperationsScenarioTest.test_prometheus_listener_metrics_page"
         # Note(coreycb): Disable watcher tests until all the failures can be debugged.
         - "watcher_tempest_plugin.*"
     bionic_queens_security:


### PR DESCRIPTION
    Various fixes for distro tests
    
    * Update to the released bobcat charm tracks for jammy-bobcat bundle.
    * With octavia tempest tests running, octavia was hit by the OOM killer,
      so increase to mem=4096.
    * Add watcher certificate relations to bundles.
    * Exclude failing octavia prometheus test.