### PR TITLE
Drop constraints from subordinate

### DIFF
--- a/tests/distro-regression/tests/bundles/jammy-yoga.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-yoga.yaml
@@ -322,7 +322,6 @@ applications:
     options:
       amp-image-tag: 'octavia-amphora'
       retrofit-series: *series
-    constraints: mem=4096
     channel: *openstack-channel
 relations:
 - - nova-cloud-controller:amqp


### PR DESCRIPTION
Subordinates can't declare constraints, this change drops the 'constraints' stanza from octavia-diskimage-retrofit