### PR TITLE
Use 23.09 for OVN instead of 24.03

### DIFF
--- a/tests/distro-regression/tests/bundles/jammy-caracal.yaml
+++ b/tests/distro-regression/tests/bundles/jammy-caracal.yaml
@@ -4,7 +4,7 @@ variables:
   retrofit-uca-pocket: &retrofit-uca-pocket caracal
   openstack-channel: &openstack-channel 2024.1/edge
   ceph-channel: &ceph-channel reef/edge
-  ovn-channel: &ovn-channel 24.03/edge
+  ovn-channel: &ovn-channel 23.09/edge
   mysql-channel: &mysql-channel 8.0/edge
   rabbitmq-channel: &rabbitmq-channel 3.9/edge
   memcached-channel: &memcached-channel latest/edge


### PR DESCRIPTION
The 24.03 channel does not exist yet. This causes linting to fail when processing the Jammy Caracal bundle. This fixes issue 133.