### PR TITLE
Pin python-libjuju for OpenStack<=bobcat

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,2 @@
+# Pin python-libjuju until it gets validated against juju-3.x
+juju<3.0.0

--- a/osci.yaml
+++ b/osci.yaml
@@ -114,6 +114,8 @@
     parent: cot-func-target
     vars:
       tox_extra_args: '-- jammy-caracal'
+      juju_snap_channel: "3.1/stable"
+      pip_constraints_url: https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt
 - job:
     name: cot_distro-regression_lunar-antelope
     parent: cot-func-target
@@ -129,6 +131,8 @@
     parent: cot-func-target
     vars:
       tox_extra_args: '-- noble-caracal'
+      juju_snap_channel: "3.1/stable"
+      pip_constraints_url: https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt
 - job:
     name: cot_distro-regression_bionic-queens-security
     parent: cot-func-target
@@ -154,6 +158,8 @@
     parent: cot-func-target
     vars:
       tox_extra_args: '-- noble-caracal-security'
+      juju_snap_channel: "3.1/stable"
+      pip_constraints_url: https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt
 - job:
     name: cot_distro-regression_focal-ussuri-to-yoga-upgrades
     parent: cot-func-target

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,9 @@ passenv =
   CS_*
   OS_*
   TEST_*
-deps = -r{toxinidir}/test-requirements.txt
+deps =
+  -c{env:TEST_CONSTRAINTS_FILE:{toxinidir}/constraints.txt}
+  -r{toxinidir}/test-requirements.txt
 install_command =
   pip install {opts} {packages}
 


### PR DESCRIPTION
OpenStack<=bobcat has been validated by charmed-openstack-tester, while juju-3.x is being introduced for OpenStack 2024.1 (Caracal).

This change introduces a constraints file which by default pins python-libjuju<3.0.0 while zaza-openstack-tests constraints file is used for the *-caracal jobs and the juju_snap_channel set to 3.1/stable